### PR TITLE
Add Android city search UI

### DIFF
--- a/android/app/src/main/java/com/bfalls/suntimealerts/MainActivity.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/MainActivity.kt
@@ -45,10 +45,12 @@ class MainActivity : ComponentActivity() {
             val locationService = remember { LocationService(application) }
             val notificationScheduler = remember { NotificationScheduler(applicationContext) }
             val scheduleService = remember { SunScheduleService(SunTimesCalculator(), settingsStore, notificationScheduler) }
-            val homeViewModel = remember { HomeViewModel(locationService, settingsStore, scheduleService) }
-            val onboardingViewModel: OnboardingViewModel = viewModel(factory = OnboardingViewModelFactory(settingsStore))
-            val onboardingState by onboardingViewModel.state.collectAsState()
             val cityRepository = remember { CityRepository(applicationContext) }
+            val homeViewModel = remember { HomeViewModel(locationService, settingsStore, scheduleService) }
+            val onboardingViewModel: OnboardingViewModel = viewModel(
+                factory = OnboardingViewModelFactory(settingsStore, cityRepository)
+            )
+            val onboardingState by onboardingViewModel.state.collectAsState()
             val cityImportViewModel: CityImportViewModel = viewModel(
                 factory = CityImportViewModelFactory(cityRepository)
             )
@@ -66,8 +68,8 @@ class MainActivity : ComponentActivity() {
                         onSunsetEnabledChanged = onboardingViewModel::updateSunsetEnabled,
                         onSunriseOffsetChanged = onboardingViewModel::updateSunriseOffset,
                         onSunsetOffsetChanged = onboardingViewModel::updateSunsetOffset,
-                        onFixedLatitudeChanged = onboardingViewModel::updateFixedLatitude,
-                        onFixedLongitudeChanged = onboardingViewModel::updateFixedLongitude,
+                        onCityQueryChanged = onboardingViewModel::updateCityQuery,
+                        onCitySelected = onboardingViewModel::selectCity,
                         onNext = onboardingViewModel::nextStep,
                         onBack = onboardingViewModel::previousStep,
                         onComplete = { onboardingViewModel.complete { } },

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/OnboardingScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
 import com.bfalls.suntimealerts.alarm.presentation.viewmodel.OnboardingState
 import com.bfalls.suntimealerts.alarm.presentation.viewmodel.OnboardingStep
+import com.bfalls.suntimealerts.cities.data.City
 
 @Composable
 fun OnboardingScreen(
@@ -33,8 +34,8 @@ fun OnboardingScreen(
     onSunsetEnabledChanged: (Boolean) -> Unit,
     onSunriseOffsetChanged: (Int) -> Unit,
     onSunsetOffsetChanged: (Int) -> Unit,
-    onFixedLatitudeChanged: (String) -> Unit,
-    onFixedLongitudeChanged: (String) -> Unit,
+    onCityQueryChanged: (String) -> Unit,
+    onCitySelected: (City) -> Unit,
     onNext: () -> Unit,
     onBack: () -> Unit,
     onComplete: () -> Unit,
@@ -61,7 +62,12 @@ fun OnboardingScreen(
 
             when (state.step) {
                 OnboardingStep.WELCOME -> WelcomeStep()
-                OnboardingStep.LOCATION -> LocationStep(state, onLocationModeChanged, onFixedLatitudeChanged, onFixedLongitudeChanged)
+                OnboardingStep.LOCATION -> LocationStep(
+                    state,
+                    onLocationModeChanged,
+                    onCityQueryChanged,
+                    onCitySelected
+                )
                 OnboardingStep.NOTIFICATIONS -> NotificationStep(state.notificationsEnabled, onNotificationsChanged)
                 OnboardingStep.ALARMS -> AlarmStep(state, onSunriseEnabledChanged, onSunsetEnabledChanged, onSunriseOffsetChanged, onSunsetOffsetChanged)
                 OnboardingStep.SUMMARY -> SummaryStep(state)
@@ -98,8 +104,8 @@ private fun WelcomeStep() {
 private fun LocationStep(
     state: OnboardingState,
     onLocationModeChanged: (LocationMode) -> Unit,
-    onFixedLatitudeChanged: (String) -> Unit,
-    onFixedLongitudeChanged: (String) -> Unit
+    onCityQueryChanged: (String) -> Unit,
+    onCitySelected: (City) -> Unit
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Text("How should we find your location?")
@@ -113,17 +119,46 @@ private fun LocationStep(
         }
         if (state.locationMode == LocationMode.FIXED) {
             OutlinedTextField(
-                value = state.fixedLatitude,
-                onValueChange = onFixedLatitudeChanged,
-                label = { Text("Latitude") },
+                value = state.cityQuery,
+                onValueChange = onCityQueryChanged,
+                label = { Text("City") },
+                placeholder = { Text("Start typing a city name") },
                 modifier = Modifier.fillMaxWidth()
             )
-            OutlinedTextField(
-                value = state.fixedLongitude,
-                onValueChange = onFixedLongitudeChanged,
-                label = { Text("Longitude") },
-                modifier = Modifier.fillMaxWidth()
-            )
+            if (state.cityQuery.trim().length >= 2) {
+                if (state.cityResults.isEmpty()) {
+                    Text("No matching cities yet")
+                } else {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        state.cityResults.take(8).forEach { city ->
+                            OutlinedButton(
+                                onClick = { onCitySelected(city) },
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Column {
+                                    Text("${city.name}, ${city.countryCode}")
+                                    Text("${city.admin1Code} · ${city.lat}, ${city.lon}")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            when {
+                state.selectedCity != null -> {
+                    val selected = state.selectedCity
+                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Text("Selected city")
+                        Text("${selected.name}, ${selected.countryCode}")
+                        Text("Lat/Lon: ${selected.lat}, ${selected.lon}")
+                    }
+                }
+
+                state.fixedLatitude.isNotBlank() && state.fixedLongitude.isNotBlank() -> {
+                    Text("Current coordinates: ${state.fixedLatitude}, ${state.fixedLongitude}")
+                }
+            }
         }
     }
 }
@@ -176,7 +211,16 @@ private fun AlarmStep(
 @Composable
 private fun SummaryStep(state: OnboardingState) {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        Text("Location: ${if (state.locationMode == LocationMode.DEVICE) "Device" else "Manual"}")
+        val locationSummary = if (state.locationMode == LocationMode.DEVICE) {
+            "Device"
+        } else {
+            when {
+                state.selectedCity != null -> "${state.selectedCity.name}, ${state.selectedCity.countryCode}"
+                state.fixedLatitude.isNotBlank() && state.fixedLongitude.isNotBlank() -> "Lat ${state.fixedLatitude}, Lon ${state.fixedLongitude}"
+                else -> "Manual coordinates"
+            }
+        }
+        Text("Location: $locationSummary")
         Text("Sunrise alarm: ${if (state.sunriseEnabled) "On" else "Off"} @ ${state.sunriseOffsetMinutes} min")
         Text("Sunset alarm: ${if (state.sunsetEnabled) "On" else "Off"} @ ${state.sunsetOffsetMinutes} min")
     }

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/OnboardingViewModel.kt
@@ -7,6 +7,9 @@ import com.bfalls.suntimealerts.alarm.data.SettingsStore
 import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
 import com.bfalls.suntimealerts.alarm.domain.model.SunAlarmConfig
 import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
+import com.bfalls.suntimealerts.cities.data.City
+import com.bfalls.suntimealerts.cities.data.CityRepository
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -16,8 +19,11 @@ data class OnboardingState(
     val isLoaded: Boolean = false,
     val onboardingComplete: Boolean = false,
     val locationMode: LocationMode = LocationMode.DEVICE,
-    val fixedLatitude: String = "0.0",
-    val fixedLongitude: String = "0.0",
+    val fixedLatitude: String = "",
+    val fixedLongitude: String = "",
+    val cityQuery: String = "",
+    val cityResults: List<City> = emptyList(),
+    val selectedCity: City? = null,
     val notificationsEnabled: Boolean = true,
     val sunriseEnabled: Boolean = true,
     val sunriseOffsetMinutes: Int = 0,
@@ -27,9 +33,14 @@ data class OnboardingState(
 
 enum class OnboardingStep { WELCOME, LOCATION, NOTIFICATIONS, ALARMS, SUMMARY }
 
-class OnboardingViewModel(private val settingsStore: SettingsStore) : ViewModel() {
+class OnboardingViewModel(
+    private val settingsStore: SettingsStore,
+    private val cityRepository: CityRepository
+) : ViewModel() {
     private val _state = MutableStateFlow(OnboardingState())
     val state: StateFlow<OnboardingState> = _state
+
+    private var searchJob: Job? = null
 
     init {
         viewModelScope.launch { load() }
@@ -41,8 +52,8 @@ class OnboardingViewModel(private val settingsStore: SettingsStore) : ViewModel(
             isLoaded = true,
             onboardingComplete = settings.onboardingComplete,
             locationMode = settings.locationMode,
-            fixedLatitude = settings.fixedLocation?.latitude?.toString() ?: "0.0",
-            fixedLongitude = settings.fixedLocation?.longitude?.toString() ?: "0.0",
+            fixedLatitude = settings.fixedLocation?.latitude?.toString() ?: "",
+            fixedLongitude = settings.fixedLocation?.longitude?.toString() ?: "",
             notificationsEnabled = settings.sunriseConfig.enabled || settings.sunsetConfig.enabled,
             sunriseEnabled = settings.sunriseConfig.enabled,
             sunriseOffsetMinutes = settings.sunriseConfig.offsetMinutes,
@@ -65,12 +76,27 @@ class OnboardingViewModel(private val settingsStore: SettingsStore) : ViewModel(
         _state.value = _state.value.copy(locationMode = mode)
     }
 
-    fun updateFixedLatitude(text: String) {
-        _state.value = _state.value.copy(fixedLatitude = text)
+    fun updateCityQuery(query: String) {
+        _state.value = _state.value.copy(cityQuery = query, selectedCity = null)
+
+        searchJob?.cancel()
+        searchJob = viewModelScope.launch {
+            val results = if (query.trim().length >= 2) {
+                cityRepository.searchCities(query)
+            } else {
+                emptyList()
+            }
+            _state.value = _state.value.copy(cityResults = results)
+        }
     }
 
-    fun updateFixedLongitude(text: String) {
-        _state.value = _state.value.copy(fixedLongitude = text)
+    fun selectCity(city: City) {
+        _state.value = _state.value.copy(
+            selectedCity = city,
+            cityQuery = "${city.name}, ${city.countryCode}",
+            fixedLatitude = city.lat.toString(),
+            fixedLongitude = city.lon.toString()
+        )
     }
 
     fun updateNotifications(enabled: Boolean) {
@@ -103,7 +129,10 @@ class OnboardingViewModel(private val settingsStore: SettingsStore) : ViewModel(
         val current = _state.value
         return when (current.step) {
             OnboardingStep.LOCATION -> if (current.locationMode == LocationMode.FIXED) {
-                current.fixedLatitude.toDoubleOrNull() != null && current.fixedLongitude.toDoubleOrNull() != null
+                current.selectedCity != null || (
+                    current.fixedLatitude.toDoubleOrNull() != null &&
+                        current.fixedLongitude.toDoubleOrNull() != null
+                    )
             } else true
             else -> true
         }
@@ -138,11 +167,14 @@ class OnboardingViewModel(private val settingsStore: SettingsStore) : ViewModel(
     }
 }
 
-class OnboardingViewModelFactory(private val settingsStore: SettingsStore) : ViewModelProvider.Factory {
+class OnboardingViewModelFactory(
+    private val settingsStore: SettingsStore,
+    private val cityRepository: CityRepository
+) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(OnboardingViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
-            return OnboardingViewModel(settingsStore) as T
+            return OnboardingViewModel(settingsStore, cityRepository) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }


### PR DESCRIPTION
- Added onboarding state management for city search queries, results, and selections to populate fixed coordinates when using manual location.
- Added a city search UI that lists matches, lets users pick a city, and shows the chosen coordinates in both the location step and summary.
- Shared the CityRepository with the onboarding flow so manual location uses imported city data while keeping the existing import overlay intact.