### PR TITLE
Add nearest city lookup for device location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ fastlane/test_output
 *.swo
 *.orig
 *.patch
+*.zip
 
 # Temp / backup
 *.tmp

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/android/app/src/main/java/com/bfalls/suntimealerts/MainActivity.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/MainActivity.kt
@@ -48,7 +48,7 @@ class MainActivity : ComponentActivity() {
             val cityRepository = remember { CityRepository(applicationContext) }
             val homeViewModel = remember { HomeViewModel(locationService, settingsStore, scheduleService) }
             val onboardingViewModel: OnboardingViewModel = viewModel(
-                factory = OnboardingViewModelFactory(settingsStore, cityRepository)
+                factory = OnboardingViewModelFactory(settingsStore, cityRepository, locationService)
             )
             val onboardingState by onboardingViewModel.state.collectAsState()
             val cityImportViewModel: CityImportViewModel = viewModel(

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/data/LocationService.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/data/LocationService.kt
@@ -3,18 +3,64 @@ package com.bfalls.suntimealerts.alarm.data
 import android.annotation.SuppressLint
 import android.app.Application
 import android.location.Location
+import android.util.Log
 import com.bfalls.suntimealerts.alarm.domain.model.Coordinate
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import com.google.android.gms.tasks.CancellationTokenSource
 import kotlinx.coroutines.tasks.await
 
 
 class LocationService(application: Application) {
-    private val client: FusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(application)
+    private val client: FusedLocationProviderClient =
+        LocationServices.getFusedLocationProviderClient(application)
 
     @SuppressLint("MissingPermission")
     suspend fun currentCoordinate(): Coordinate? {
-        val location: Location = client.lastLocation.await() ?: return null
-        return Coordinate(location.latitude, location.longitude)
+        return try {
+            Log.d("LocationService", "Requesting current location…")
+            // Prefer a fresh location fix when possible
+            val cts = CancellationTokenSource()
+
+            val current: Location? = try {
+                client.getCurrentLocation(
+                    Priority.PRIORITY_HIGH_ACCURACY,
+                    cts.token
+                )
+                    .await()
+            } catch (t: Throwable) {
+                Log.w("LocationService", "getCurrentLocation failed: $t")
+                null
+            }
+
+            Log.d("LocationService", "getCurrentLocation result = $current")
+
+            val last: Location? = if (current == null) {
+                val lastLoc = client.lastLocation.await()
+                Log.d("LocationService", "lastLocation result = $lastLoc")
+                lastLoc
+            } else {
+                null
+            }
+
+            // Fall back to last known location if no fresh fix is available
+            val effective: Location? = current ?: last
+
+            if (effective == null) {
+                Log.w("LocationService", "No location available (current or last).")
+                null
+            } else {
+                val coord = Coordinate(effective.latitude, effective.longitude)
+                Log.d("LocationService", "Using coordinate: $coord from location: $effective (source=${if (current != null) "current" else "last"})")
+                coord
+            }
+        } catch (se: SecurityException) {
+            Log.e("LocationService", "Location permission not granted", se)
+            null
+        } catch (t: Throwable) {
+            Log.e("LocationService", "Error retrieving location", t)
+            null
+        }
     }
 }

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/OnboardingScreen.kt
@@ -251,6 +251,12 @@ private fun LocationStep(
                 }
             }
         }
+        if (state.locationMode == LocationMode.DEVICE) {
+            when (val label = state.deviceNearestCityLabel) {
+                null -> Text("Resolving nearest city…")
+                else -> Text("Nearest city: $label")
+            }
+        }
     }
 }
 
@@ -303,7 +309,7 @@ private fun AlarmStep(
 private fun SummaryStep(state: OnboardingState) {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         val locationSummary = if (state.locationMode == LocationMode.DEVICE) {
-            "Device"
+            state.deviceNearestCityLabel?.let { "Device (near $it)" } ?: "Device"
         } else {
             when {
                 state.selectedCity != null -> "${state.selectedCity.name}, ${state.selectedCity.admin1Code}, ${state.selectedCity.countryCode}"

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/OnboardingViewModel.kt
@@ -1,8 +1,10 @@
 package com.bfalls.suntimealerts.alarm.presentation.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.bfalls.suntimealerts.alarm.data.LocationService
 import com.bfalls.suntimealerts.alarm.data.SettingsStore
 import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
 import com.bfalls.suntimealerts.alarm.domain.model.SunAlarmConfig
@@ -19,6 +21,7 @@ data class OnboardingState(
     val isLoaded: Boolean = false,
     val onboardingComplete: Boolean = false,
     val locationMode: LocationMode = LocationMode.DEVICE,
+    val deviceNearestCityLabel: String? = null,
     val fixedLatitude: String = "",
     val fixedLongitude: String = "",
     val cityQuery: String = "",
@@ -35,12 +38,14 @@ enum class OnboardingStep { WELCOME, LOCATION, NOTIFICATIONS, ALARMS, SUMMARY }
 
 class OnboardingViewModel(
     private val settingsStore: SettingsStore,
-    private val cityRepository: CityRepository
+    private val cityRepository: CityRepository,
+    private val locationService: LocationService
 ) : ViewModel() {
     private val _state = MutableStateFlow(OnboardingState())
     val state: StateFlow<OnboardingState> = _state
 
     private var searchJob: Job? = null
+    private var nearestCityJob: Job? = null
 
     init {
         viewModelScope.launch { load() }
@@ -60,6 +65,10 @@ class OnboardingViewModel(
             sunsetEnabled = settings.sunsetConfig.enabled,
             sunsetOffsetMinutes = settings.sunsetConfig.offsetMinutes
         )
+
+        if (settings.locationMode == LocationMode.DEVICE) {
+            refreshDeviceNearestCity()
+        }
     }
 
     fun nextStep() {
@@ -73,7 +82,13 @@ class OnboardingViewModel(
     }
 
     fun updateLocationMode(mode: LocationMode) {
-        _state.value = _state.value.copy(locationMode = mode)
+        _state.value = _state.value.copy(
+            locationMode = mode,
+            deviceNearestCityLabel = if (mode == LocationMode.DEVICE) null else _state.value.deviceNearestCityLabel
+        )
+        if (mode == LocationMode.DEVICE) {
+            refreshDeviceNearestCity()
+        }
     }
 
     fun updateCityQuery(query: String) {
@@ -130,10 +145,11 @@ class OnboardingViewModel(
         return when (current.step) {
             OnboardingStep.LOCATION -> if (current.locationMode == LocationMode.FIXED) {
                 current.selectedCity != null || (
-                    current.fixedLatitude.toDoubleOrNull() != null &&
-                        current.fixedLongitude.toDoubleOrNull() != null
-                    )
+                        current.fixedLatitude.toDoubleOrNull() != null &&
+                                current.fixedLongitude.toDoubleOrNull() != null
+                        )
             } else true
+
             else -> true
         }
     }
@@ -158,23 +174,63 @@ class OnboardingViewModel(
             if (settings.locationMode == LocationMode.FIXED) {
                 val lat = _state.value.fixedLatitude.toDoubleOrNull() ?: 0.0
                 val lon = _state.value.fixedLongitude.toDoubleOrNull() ?: 0.0
-                settings = settings.copy(fixedLocation = com.bfalls.suntimealerts.alarm.domain.model.Coordinate(lat, lon))
+                settings = settings.copy(
+                    fixedLocation = com.bfalls.suntimealerts.alarm.domain.model.Coordinate(
+                        lat,
+                        lon
+                    )
+                )
             }
             settingsStore.save(settings)
             _state.value = _state.value.copy(onboardingComplete = true)
             onFinished()
         }
     }
+
+    private fun refreshDeviceNearestCity() {
+        nearestCityJob?.cancel()
+        nearestCityJob = viewModelScope.launch {
+            Log.d("OnboardingViewModel", "Requesting device location for nearest city")
+
+            val coordinate = locationService.currentCoordinate() ?: run {
+                Log.w(
+                    "OnboardingViewModel",
+                    "Device coordinate unavailable; cannot compute nearest city"
+                )
+                return@launch
+            }
+
+            Log.d("OnboardingViewModel", "Got coordinate from device: $coordinate")
+
+            val nearest = cityRepository.findNearestCity(
+                coordinate.latitude,
+                coordinate.longitude
+            )
+            Log.d("OnboardingViewModel", "Nearest city for $coordinate is $nearest")
+            val label = nearest?.let { formatNearestCityLabel(it) }
+            _state.value = _state.value.copy(deviceNearestCityLabel = label)
+        }
+    }
+
+    private fun formatNearestCityLabel(city: City): String {
+        val region = city.admin1Code.takeIf { it.isNotBlank() }
+        return if (region != null) {
+            "${city.name}, $region, ${city.countryCode}"
+        } else {
+            "${city.name}, ${city.countryCode}"
+        }
+    }
 }
 
 class OnboardingViewModelFactory(
     private val settingsStore: SettingsStore,
-    private val cityRepository: CityRepository
+    private val cityRepository: CityRepository,
+    private val locationService: LocationService
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(OnboardingViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
-            return OnboardingViewModel(settingsStore, cityRepository) as T
+            return OnboardingViewModel(settingsStore, cityRepository, locationService) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/android/app/src/main/java/com/bfalls/suntimealerts/cities/data/CityRepository.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/cities/data/CityRepository.kt
@@ -3,6 +3,8 @@ package com.bfalls.suntimealerts.cities.data
 import android.content.Context
 import android.util.Log
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
 
@@ -22,84 +24,87 @@ class CityRepository(
 ) {
 
     private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val importMutex = Mutex()
 
     suspend fun ensureCitiesLoaded(
         onProgress: ((CityImportProgress) -> Unit)? = null
     ) = withContext(Dispatchers.IO) {
-        val storedVersion = prefs.getInt(KEY_CITY_DATA_VERSION, 0)
-        if (storedVersion == CITY_DATA_VERSION) {
-            // Already imported this version
-            return@withContext
-        }
-
-        Log.d("CityRepository", "Importing cities from assets...")
-
-        val db = dbHelper.writableDatabase
-        db.beginTransaction()
-        try {
-            db.execSQL("DELETE FROM cities;")
-
-            val json = context.assets.open(ASSET_FILE_NAME).use { input ->
-                input.bufferedReader(Charsets.UTF_8).readText()
+        importMutex.withLock {
+            val storedVersion = prefs.getInt(KEY_CITY_DATA_VERSION, 0)
+            if (storedVersion == CITY_DATA_VERSION) {
+                // Already imported this version
+                return@withLock
             }
 
-            val array = JSONArray(json)
-            val total = array.length().coerceAtLeast(1)
+            Log.d("CityRepository", "Importing cities from assets...")
 
-            val insertSql = """
-                INSERT INTO cities (
-                    id, name, asciiName, countryCode, admin1Code, lat, lon, timezone, population
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """.trimIndent()
-            val stmt = db.compileStatement(insertSql)
+            val db = dbHelper.writableDatabase
+            db.beginTransaction()
+            try {
+                db.execSQL("DELETE FROM cities;")
 
-            for (i in 0 until array.length()) {
-                val obj = array.getJSONObject(i)
+                val json = context.assets.open(ASSET_FILE_NAME).use { input ->
+                    input.bufferedReader(Charsets.UTF_8).readText()
+                }
 
-                val id = obj.getLong("id")
-                val name = obj.getString("name")
-                val asciiName = obj.getString("asciiName")
-                val countryCode = obj.getString("countryCode")
-                val admin1Code = obj.getString("admin1Code")
-                val lat = obj.getDouble("lat")
-                val lon = obj.getDouble("lon")
-                val timezone = obj.getString("timezone")
-                val population = obj.getLong("population")
+                val array = JSONArray(json)
+                val total = array.length().coerceAtLeast(1)
 
-                stmt.clearBindings()
-                stmt.bindLong(1, id)
-                stmt.bindString(2, name)
-                stmt.bindString(3, asciiName)
-                stmt.bindString(4, countryCode)
-                stmt.bindString(5, admin1Code)
-                stmt.bindDouble(6, lat)
-                stmt.bindDouble(7, lon)
-                stmt.bindString(8, timezone)
-                stmt.bindLong(9, population)
+                val insertSql = """
+                    INSERT INTO cities (
+                        id, name, asciiName, countryCode, admin1Code, lat, lon, timezone, population
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """.trimIndent()
+                val stmt = db.compileStatement(insertSql)
 
-                stmt.executeInsert()
+                for (i in 0 until array.length()) {
+                    val obj = array.getJSONObject(i)
 
-                // Report progress every so often (and on the last record)
-                if (onProgress != null) {
-                    if (i == total - 1 || i % 100 == 0) {
-                        onProgress(
-                            CityImportProgress(
-                                current = i + 1,
-                                total = total
+                    val id = obj.getLong("id")
+                    val name = obj.getString("name")
+                    val asciiName = obj.getString("asciiName")
+                    val countryCode = obj.getString("countryCode")
+                    val admin1Code = obj.getString("admin1Code")
+                    val lat = obj.getDouble("lat")
+                    val lon = obj.getDouble("lon")
+                    val timezone = obj.getString("timezone")
+                    val population = obj.getLong("population")
+
+                    stmt.clearBindings()
+                    stmt.bindLong(1, id)
+                    stmt.bindString(2, name)
+                    stmt.bindString(3, asciiName)
+                    stmt.bindString(4, countryCode)
+                    stmt.bindString(5, admin1Code)
+                    stmt.bindDouble(6, lat)
+                    stmt.bindDouble(7, lon)
+                    stmt.bindString(8, timezone)
+                    stmt.bindLong(9, population)
+
+                    stmt.executeInsert()
+
+                    // Report progress every so often (and on the last record)
+                    if (onProgress != null) {
+                        if (i == total - 1 || i % 100 == 0) {
+                            onProgress(
+                                CityImportProgress(
+                                    current = i + 1,
+                                    total = total
+                                )
                             )
-                        )
+                        }
                     }
                 }
-            }
 
-            db.setTransactionSuccessful()
-            prefs.edit().putInt(KEY_CITY_DATA_VERSION, CITY_DATA_VERSION).apply()
-            Log.d("CityRepository", "Imported $total cities.")
-        } catch (t: Throwable) {
-            Log.e("CityRepository", "Failed to import cities", t)
-            throw t
-        } finally {
-            db.endTransaction()
+                db.setTransactionSuccessful()
+                prefs.edit().putInt(KEY_CITY_DATA_VERSION, CITY_DATA_VERSION).apply()
+                Log.d("CityRepository", "Imported $total cities.")
+            } catch (t: Throwable) {
+                Log.e("CityRepository", "Failed to import cities", t)
+                throw t
+            } finally {
+                db.endTransaction()
+            }
         }
     }
 
@@ -151,5 +156,54 @@ class CityRepository(
             }
 
             cities
+        }
+
+    suspend fun findNearestCity(lat: Double, lon: Double): City? =
+        withContext(Dispatchers.IO) {
+            ensureCitiesLoaded()
+
+            val db = dbHelper.readableDatabase
+            val cursor = db.rawQuery(
+                """
+                SELECT
+                    id,
+                    name,
+                    asciiName,
+                    countryCode,
+                    admin1Code,
+                    lat,
+                    lon,
+                    timezone,
+                    population,
+                    ((lat - ?)*(lat - ?) + (lon - ?)*(lon - ?)) AS distance_sq
+                FROM cities
+                ORDER BY distance_sq ASC
+                LIMIT 1;
+                """.trimIndent(),
+                arrayOf(
+                    lat.toString(),
+                    lat.toString(),
+                    lon.toString(),
+                    lon.toString()
+                )
+            )
+
+            cursor.use {
+                if (it.moveToFirst()) {
+                    return@withContext City(
+                        id = it.getLong(0),
+                        name = it.getString(1),
+                        asciiName = it.getString(2),
+                        countryCode = it.getString(3),
+                        admin1Code = it.getString(4),
+                        lat = it.getDouble(5),
+                        lon = it.getDouble(6),
+                        timezone = it.getString(7),
+                        population = it.getLong(8)
+                    )
+                }
+            }
+
+            null
         }
 }


### PR DESCRIPTION
- Added a nearest-city query that uses the offline database to find the closest match to given coordinates.
- Onboarding state and viewmodel now track a nearest-city label for device mode, resolving it from device coordinates via LocationService and the repository without altering the coordinate source of truth.
- Updated onboarding UI to display the nearest city in device mode and include it in the summary, and wired the onboarding viewmodel factory to receive the location service dependency.

