### PR TITLE
Update onboarding flow for location refresh

### DIFF
--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/OnboardingScreen.kt
@@ -253,7 +253,7 @@ private fun LocationStep(
         }
         if (state.locationMode == LocationMode.DEVICE) {
             when (val label = state.deviceNearestCityLabel) {
-                null -> Text("Resolving nearest city…")
+                null -> Text("Finding nearest city…")
                 else -> Text("Nearest city: $label")
             }
         }

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/OnboardingViewModel.kt
@@ -195,6 +195,7 @@ class OnboardingViewModel(
     private fun refreshDeviceNearestCity() {
         nearestCityJob?.cancel()
         nearestCityJob = viewModelScope.launch {
+            _state.value = _state.value.copy(deviceNearestCityLabel = null)
             Log.d("OnboardingViewModel", "Requesting device location for nearest city")
 
             val coordinate = locationService.currentCoordinate() ?: run {


### PR DESCRIPTION
- Triggered device-nearest-city refresh whenever onboarding navigation lands on the Location step so it re-runs each time the user returns to that page.
- Stopped resolving device location during initial load, deferring the lookup until the Location page is shown.
- Cleared the stored nearest city label before launching a device location refresh so the location step shows the “Finding nearest city…” message while a new lookup is in progress.