### PR TITLE
Handle denied location permission during onboarding (Fixes #14)

### DIFF
--- a/android/app/src/main/java/com/bfalls/suntimealerts/MainActivity.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/MainActivity.kt
@@ -1,6 +1,8 @@
 package com.bfalls.suntimealerts
 
 import android.Manifest
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
@@ -33,6 +35,7 @@ import com.bfalls.suntimealerts.alarm.presentation.ui.OnboardingScreen
 import com.bfalls.suntimealerts.alarm.presentation.viewmodel.HomeViewModel
 import com.bfalls.suntimealerts.alarm.presentation.viewmodel.OnboardingViewModel
 import com.bfalls.suntimealerts.alarm.presentation.viewmodel.OnboardingViewModelFactory
+import com.bfalls.suntimealerts.alarm.presentation.viewmodel.PermissionRequestOrigin
 import com.bfalls.suntimealerts.alarm.services.NotificationScheduler
 import com.bfalls.suntimealerts.cities.data.CityRepository
 import com.bfalls.suntimealerts.cities.presentation.CityImportViewModel
@@ -41,6 +44,11 @@ import com.bfalls.suntimealerts.ui.theme.SuntimeAlertsTheme
 import com.bfalls.suntimealerts.utils.hasLocationPermission
 import androidx.compose.runtime.LaunchedEffect
 import com.bfalls.suntimealerts.alarm.presentation.viewmodel.OnboardingStep
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.getValue
+import androidx.core.app.ActivityCompat
+import android.provider.Settings
 
 
 class MainActivity : ComponentActivity() {
@@ -63,6 +71,7 @@ class MainActivity : ComponentActivity() {
                 factory = CityImportViewModelFactory(cityRepository)
             )
             val cityImportState by cityImportViewModel.state.collectAsState()
+            var permissionRequestOrigin by remember { mutableStateOf<PermissionRequestOrigin?>(null) }
             val locationPermissionLauncher =
                 rememberLauncherForActivityResult(
                     contract = ActivityResultContracts.RequestMultiplePermissions()
@@ -71,25 +80,38 @@ class MainActivity : ComponentActivity() {
                         permissions[Manifest.permission.ACCESS_FINE_LOCATION] == true ||
                                 permissions[Manifest.permission.ACCESS_COARSE_LOCATION] == true
 
+                    val shouldShowRationale =
+                        ActivityCompat.shouldShowRequestPermissionRationale(
+                            this,
+                            Manifest.permission.ACCESS_FINE_LOCATION
+                        ) || ActivityCompat.shouldShowRequestPermissionRationale(
+                            this,
+                            Manifest.permission.ACCESS_COARSE_LOCATION
+                        )
+
+                    val permanentlyDenied = !granted && !shouldShowRationale
+
+                    val origin = permissionRequestOrigin ?: PermissionRequestOrigin.AUTOMATIC
+                    permissionRequestOrigin = null
+
                     Log.d(
                         "MainActivity",
                         "Location permission result: granted=$granted perms=$permissions"
                     )
 
-                    if (granted) {
-                        // Now it’s safe to use device location
-                        onboardingViewModel.updateLocationMode(LocationMode.DEVICE)
-                    } else {
-                        // Optionally: show a message or keep them on Manual mode
-                        // e.g. onboardingViewModel.updateLocationMode(LocationMode.FIXED)
-                    }
+                    onboardingViewModel.handleLocationPermissionResult(
+                        granted = granted,
+                        permanentlyDenied = permanentlyDenied,
+                        origin = origin
+                    )
                 }
 
             LaunchedEffect(
                 onboardingState.isLoaded,
                 onboardingState.step,
                 onboardingState.locationMode,
-                onboardingState.deviceNearestCityLabel
+                onboardingState.deviceNearestCityLabel,
+                permissionRequestOrigin
             ) {
                 // If onboarding is showing the LOCATION step and is in DEVICE mode,
                 // and we don't yet have a nearest-city label, run the permission flow.
@@ -98,13 +120,17 @@ class MainActivity : ComponentActivity() {
                     !onboardingState.onboardingComplete &&
                     onboardingState.step == OnboardingStep.LOCATION &&
                     onboardingState.locationMode == LocationMode.DEVICE &&
-                    onboardingState.deviceNearestCityLabel == null
+                    onboardingState.deviceNearestCityLabel == null &&
+                    permissionRequestOrigin == null &&
+                    !onboardingState.locationPermissionPermanentlyDenied
                 ) {
                     if (hasLocationPermission(context)) {
                         // Permission already granted: trigger device-mode behavior
+                        onboardingViewModel.clearLocationPermissionDenial()
                         onboardingViewModel.updateLocationMode(LocationMode.DEVICE)
                     } else {
                         // Ask the system for permission
+                        permissionRequestOrigin = PermissionRequestOrigin.AUTOMATIC
                         locationPermissionLauncher.launch(
                             arrayOf(
                                 Manifest.permission.ACCESS_FINE_LOCATION,
@@ -143,23 +169,33 @@ class MainActivity : ComponentActivity() {
                         onLocationModeChanged = { mode ->
                             when (mode) {
                                 LocationMode.DEVICE -> {
+                                    onboardingViewModel.updateLocationMode(LocationMode.DEVICE)
+
                                     if (hasLocationPermission(context)) {
                                         // Already granted → just switch to device mode
-                                        onboardingViewModel.updateLocationMode(LocationMode.DEVICE)
-                                    } else {
-                                        // Trigger system permission dialog
-                                        locationPermissionLauncher.launch(
-                                            arrayOf(
-                                                Manifest.permission.ACCESS_FINE_LOCATION,
-                                                Manifest.permission.ACCESS_COARSE_LOCATION
-                                            )
-                                        )
+                                        onboardingViewModel.clearLocationPermissionDenial()
+                                        return@OnboardingScreen
                                     }
+
+                                    // Trigger system permission dialog after the UI switches to device mode
+                                    permissionRequestOrigin = PermissionRequestOrigin.USER
+                                    locationPermissionLauncher.launch(
+                                        arrayOf(
+                                            Manifest.permission.ACCESS_FINE_LOCATION,
+                                            Manifest.permission.ACCESS_COARSE_LOCATION
+                                        )
+                                    )
                                 }
                                 LocationMode.FIXED -> {
                                     onboardingViewModel.updateLocationMode(LocationMode.FIXED)
                                 }
                             }
+                        },
+                        onOpenPermissionSettings = {
+                            val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                                data = Uri.fromParts("package", packageName, null)
+                            }
+                            startActivity(intent)
                         },
                         onNotificationsChanged = onboardingViewModel::updateNotifications,
                         onSunriseEnabledChanged = onboardingViewModel::updateSunriseEnabled,

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/data/LocationService.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/data/LocationService.kt
@@ -31,6 +31,11 @@ class LocationService(private val application: Application) {
             Manifest.permission.ACCESS_COARSE_LOCATION
         ) == PackageManager.PERMISSION_GRANTED
 
+        Log.d(
+            "LocationService",
+            "Permission check: fineGranted=$fineGranted coarseGranted=$coarseGranted"
+        )
+
         if (!fineGranted && !coarseGranted) {
             Log.w("LocationService", "No location permission; returning null")
             return null

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/OnboardingScreen.kt
@@ -58,6 +58,7 @@ fun OnboardingScreen(
     onSunsetEnabledChanged: (Boolean) -> Unit,
     onSunriseOffsetChanged: (Int) -> Unit,
     onSunsetOffsetChanged: (Int) -> Unit,
+    onOpenPermissionSettings: () -> Unit,
     onCityQueryChanged: (String) -> Unit,
     onCitySelected: (City) -> Unit,
     onNext: () -> Unit,
@@ -118,6 +119,7 @@ fun OnboardingScreen(
                     OnboardingStep.LOCATION -> LocationStep(
                         state,
                         onLocationModeChanged,
+                        onOpenPermissionSettings,
                         onCityQueryChanged,
                         onCitySelected
                     )
@@ -142,6 +144,7 @@ private fun WelcomeStep() {
 private fun LocationStep(
     state: OnboardingState,
     onLocationModeChanged: (LocationMode) -> Unit,
+    onOpenPermissionSettings: () -> Unit,
     onCityQueryChanged: (String) -> Unit,
     onCitySelected: (City) -> Unit
 ) {
@@ -255,6 +258,15 @@ private fun LocationStep(
             when (val label = state.deviceNearestCityLabel) {
                 null -> Text("Finding nearest city…")
                 else -> Text("Nearest city: $label")
+            }
+
+            if (state.locationPermissionPermanentlyDenied) {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Location permission is disabled. Open Settings to enable device location.")
+                    OutlinedButton(onClick = onOpenPermissionSettings) {
+                        Text("Open Settings")
+                    }
+                }
             }
         }
     }

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/OnboardingViewModel.kt
@@ -21,6 +21,7 @@ data class OnboardingState(
     val isLoaded: Boolean = false,
     val onboardingComplete: Boolean = false,
     val locationMode: LocationMode = LocationMode.DEVICE,
+    val locationPermissionPermanentlyDenied: Boolean = false,
     val deviceNearestCityLabel: String? = null,
     val fixedLatitude: String = "",
     val fixedLongitude: String = "",
@@ -35,6 +36,8 @@ data class OnboardingState(
 )
 
 enum class OnboardingStep { WELCOME, LOCATION, NOTIFICATIONS, ALARMS, SUMMARY }
+
+enum class PermissionRequestOrigin { AUTOMATIC, USER }
 
 class OnboardingViewModel(
     private val settingsStore: SettingsStore,
@@ -86,6 +89,39 @@ class OnboardingViewModel(
         )
         if (mode == LocationMode.DEVICE) {
             refreshDeviceNearestCity()
+        }
+    }
+
+    fun handleLocationPermissionResult(
+        granted: Boolean,
+        permanentlyDenied: Boolean,
+        origin: PermissionRequestOrigin
+    ) {
+        val current = _state.value
+
+        if (granted) {
+            _state.value = current.copy(locationPermissionPermanentlyDenied = false)
+            updateLocationMode(LocationMode.DEVICE)
+            return
+        }
+
+        val updated = current.copy(locationPermissionPermanentlyDenied = permanentlyDenied)
+        _state.value = updated
+
+        if (
+            !permanentlyDenied &&
+            !current.onboardingComplete &&
+            current.step == OnboardingStep.LOCATION &&
+            current.locationMode == LocationMode.DEVICE
+        ) {
+            _state.value = updated.copy(locationMode = LocationMode.FIXED)
+        }
+    }
+
+    fun clearLocationPermissionDenial() {
+        val current = _state.value
+        if (current.locationPermissionPermanentlyDenied) {
+            _state.value = current.copy(locationPermissionPermanentlyDenied = false)
         }
     }
 


### PR DESCRIPTION
- Tracked and persisted a permanent-location-denial flag in the onboarding state so denied results only fall back to Manual mode when appropriate and the flag clears once permission returns.
- Kept the device-mode-first flow while showing an inline message and Settings shortcut on the device location screen whenever permission is permanently denied.
- Updated onboarding permission handling to respect `shouldShowRequestPermissionRationale`, avoid repeated automatic prompts after permanent denial, and provide an app-settings link from the device-mode flow.