### PR TITLE
Replace home UI with clock-style alarms

### DIFF
--- a/android/app/src/androidTest/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreenAppBarTest.kt
+++ b/android/app/src/androidTest/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreenAppBarTest.kt
@@ -1,0 +1,85 @@
+package com.bfalls.suntimealerts.alarm.presentation.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import com.bfalls.suntimealerts.alarm.data.LocationProvider
+import com.bfalls.suntimealerts.alarm.data.SettingsRepository
+import com.bfalls.suntimealerts.alarm.data.SunScheduler
+import com.bfalls.suntimealerts.alarm.domain.model.Coordinate
+import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
+import com.bfalls.suntimealerts.alarm.domain.model.SunAlarm
+import com.bfalls.suntimealerts.alarm.domain.model.SunAlarmConfig
+import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
+import com.bfalls.suntimealerts.alarm.domain.model.UserSettings
+import com.bfalls.suntimealerts.alarm.domain.service.SunTimesCalculator
+import com.bfalls.suntimealerts.ui.theme.SuntimeAlertsTheme
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import java.time.ZoneId
+
+class HomeScreenAppBarTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun rendersBackgroundAndLists() = runBlocking {
+        val alarms = listOf(
+            SunAlarm(
+                type = SunEventType.SUNRISE,
+                offsetMinutes = 30,
+                label = "Test alarm",
+                enabled = true
+            ),
+            SunAlarm(
+                type = SunEventType.SUNSET,
+                offsetMinutes = -15,
+                label = "Evening",
+                enabled = true
+            )
+        )
+        val settingsRepo = object : SettingsRepository {
+            override suspend fun load(): UserSettings = UserSettings(
+                locationMode = LocationMode.FIXED,
+                fixedLocation = Coordinate(0.0, 0.0),
+                sunriseConfig = SunAlarmConfig(true, SunEventType.SUNRISE, 0),
+                sunsetConfig = SunAlarmConfig(true, SunEventType.SUNSET, 0),
+                timeFormat24h = true,
+                onboardingComplete = true,
+                alarms = alarms
+            )
+
+            override suspend fun save(settings: UserSettings) = Unit
+            override suspend fun loadAlarms(): List<SunAlarm> = alarms
+            override suspend fun saveAlarms(alarms: List<SunAlarm>) = Unit
+        }
+        val viewModel = HomeViewModel(
+            locationService = object : LocationProvider {
+                override suspend fun currentCoordinate(): Coordinate? = Coordinate(0.0, 0.0)
+            },
+            settingsStore = settingsRepo,
+            scheduleService = object : SunScheduler {
+                override suspend fun schedule(coordinate: Coordinate, zoneId: ZoneId) = Unit
+            },
+            sunTimesCalculator = SunTimesCalculator()
+        )
+
+        composeRule.setContent {
+            SuntimeAlertsTheme {
+                HomeScreen(viewModel)
+            }
+        }
+
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag("sun_appbar_background").assertIsDisplayed()
+        composeRule.onNodeWithText("Sunrise").assertExists()
+        composeRule.onNodeWithText("Sunset").assertExists()
+        composeRule.onNodeWithText("+30m").assertExists()
+    }
+}

--- a/android/app/src/main/java/com/bfalls/suntimealerts/MainActivity.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/MainActivity.kt
@@ -63,9 +63,10 @@ class MainActivity : ComponentActivity() {
             val settingsStore = remember { SettingsStore(applicationContext) }
             val locationService = remember { LocationService(application) }
             val notificationScheduler = remember { NotificationScheduler(applicationContext) }
-            val scheduleService = remember { SunScheduleService(SunTimesCalculator(), settingsStore, notificationScheduler) }
+            val sunTimesCalculator = remember { SunTimesCalculator() }
+            val scheduleService = remember { SunScheduleService(sunTimesCalculator, settingsStore, notificationScheduler) }
             val cityRepository = remember { CityRepository(applicationContext) }
-            val homeViewModel = remember { HomeViewModel(locationService, settingsStore, scheduleService) }
+            val homeViewModel = remember { HomeViewModel(locationService, settingsStore, scheduleService, sunTimesCalculator) }
             val onboardingViewModel: OnboardingViewModel = viewModel(
                 factory = OnboardingViewModelFactory(settingsStore, cityRepository, locationService)
             )

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/data/SettingsStore.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/data/SettingsStore.kt
@@ -5,17 +5,25 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.doublePreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.bfalls.suntimealerts.alarm.domain.model.Coordinate
 import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
+import com.bfalls.suntimealerts.alarm.domain.model.SunAlarm
 import com.bfalls.suntimealerts.alarm.domain.model.SunAlarmConfig
 import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
 import com.bfalls.suntimealerts.alarm.domain.model.UserSettings
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.flow.first
+import java.util.UUID
 
 interface SettingsRepository {
     suspend fun load(): UserSettings
     suspend fun save(settings: UserSettings)
+    suspend fun loadAlarms(): List<SunAlarm>
+    suspend fun saveAlarms(alarms: List<SunAlarm>)
 }
 
 private val Context.dataStore by preferencesDataStore("sunriseSunset")
@@ -29,6 +37,8 @@ class SettingsStore(private val context: Context) : SettingsRepository {
     private val fixedLat = doublePreferencesKey("fixed_lat")
     private val fixedLon = doublePreferencesKey("fixed_lon")
     private val onboarding = booleanPreferencesKey("onboarding")
+    private val alarmsJson = stringPreferencesKey("alarms_json")
+    private val gson = Gson()
 
     override suspend fun load(): UserSettings {
         val prefs = context.dataStore.data.first()
@@ -51,13 +61,20 @@ class SettingsStore(private val context: Context) : SettingsRepository {
             prefs[fixedLat] ?: 0.0,
             prefs[fixedLon] ?: 0.0
         ) else null
+        val storedAlarms = loadAlarmsInternal(prefs)
+        val alarms = if (storedAlarms.isNotEmpty()) {
+            storedAlarms
+        } else {
+            migrateAlarms(prefs).also { saveAlarms(it) }
+        }
         return UserSettings(
             locationMode = locationMode,
             fixedLocation = fixed,
             sunriseConfig = sunriseConfig,
             sunsetConfig = sunsetConfig,
             timeFormat24h = prefs[time24h] ?: true,
-            onboardingComplete = prefs[onboarding] ?: false
+            onboardingComplete = prefs[onboarding] ?: false,
+            alarms = alarms
         )
     }
 
@@ -77,6 +94,59 @@ class SettingsStore(private val context: Context) : SettingsRepository {
                 prefs.remove(fixedLat)
                 prefs.remove(fixedLon)
             }
+            prefs[alarmsJson] = gson.toJson(settings.alarms)
         }
     }
+
+    override suspend fun loadAlarms(): List<SunAlarm> {
+        val prefs = context.dataStore.data.first()
+        val stored = loadAlarmsInternal(prefs)
+        if (stored.isNotEmpty()) return stored
+
+        val migrated = migrateAlarms(prefs)
+        saveAlarms(migrated)
+        return migrated
+    }
+
+    override suspend fun saveAlarms(alarms: List<SunAlarm>) {
+        context.dataStore.edit { prefs ->
+            prefs[alarmsJson] = gson.toJson(alarms)
+        }
+    }
+
+    private fun loadAlarmsInternal(prefs: Preferences): List<SunAlarm> {
+        val json = prefs[alarmsJson] ?: return emptyList()
+        if (json.isBlank()) return emptyList()
+        val type = object : TypeToken<List<SunAlarm>>() {}.type
+        return gson.fromJson(json, type) ?: emptyList()
+    }
+
+    private fun migrateAlarms(prefs: Preferences): List<SunAlarm> = migrateLegacyAlarms(
+        sunriseEnabled = prefs[sunriseEnabled] ?: true,
+        sunriseOffset = prefs[sunriseOffset] ?: 0,
+        sunsetEnabled = prefs[sunsetEnabled] ?: false,
+        sunsetOffset = prefs[sunsetOffset] ?: 0
+    )
 }
+
+internal fun migrateLegacyAlarms(
+    sunriseEnabled: Boolean,
+    sunriseOffset: Int,
+    sunsetEnabled: Boolean,
+    sunsetOffset: Int
+): List<SunAlarm> = listOf(
+    SunAlarm(
+        id = UUID.randomUUID().toString(),
+        type = SunEventType.SUNRISE,
+        offsetMinutes = sunriseOffset,
+        label = "Sunrise",
+        enabled = sunriseEnabled
+    ),
+    SunAlarm(
+        id = UUID.randomUUID().toString(),
+        type = SunEventType.SUNSET,
+        offsetMinutes = sunsetOffset,
+        label = "Sunset",
+        enabled = sunsetEnabled
+    )
+)

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/data/SunScheduleService.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/data/SunScheduleService.kt
@@ -1,11 +1,9 @@
 package com.bfalls.suntimealerts.alarm.data
 
 import com.bfalls.suntimealerts.alarm.domain.model.Coordinate
-import com.bfalls.suntimealerts.alarm.domain.model.SunAlarmConfig
-import com.bfalls.suntimealerts.alarm.domain.model.SunEvent
 import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
 import com.bfalls.suntimealerts.alarm.domain.service.SunTimesCalculator
-import com.bfalls.suntimealerts.alarm.services.NotificationScheduler
+import com.bfalls.suntimealerts.alarm.services.AlarmScheduler
 import java.time.LocalDate
 import java.time.ZoneId
 
@@ -16,38 +14,30 @@ interface SunScheduler {
 class SunScheduleService(
     private val calculator: SunTimesCalculator,
     private val settingsStore: SettingsRepository,
-    private val notificationScheduler: NotificationScheduler
+    private val notificationScheduler: AlarmScheduler
 ) : SunScheduler {
     override suspend fun schedule(coordinate: Coordinate, zoneId: ZoneId) {
-        val settings = settingsStore.load()
+        val alarms = settingsStore.loadAlarms()
         val today = LocalDate.now(zoneId)
         val dates = listOf(today, today.plusDays(1))
         notificationScheduler.cancelAll()
         dates.forEach { date ->
             val times = calculator.calculateSunTimes(date, coordinate, zoneId)
-            val events = buildList {
-                times.sunrise?.let { add(
-                    SunEvent(
-                        date.toEpochDay(),
-                        SunEventType.SUNRISE,
-                        it.toInstant().toEpochMilli(),
-                        coordinate
-                    )
-                ) }
-                times.sunset?.let { add(
-                    SunEvent(
-                        date.toEpochDay(),
-                        SunEventType.SUNSET,
-                        it.toInstant().toEpochMilli(),
-                        coordinate
-                    )
-                ) }
-            }
-            events.forEach { event ->
-                val config: SunAlarmConfig = if (event.type == SunEventType.SUNRISE) settings.sunriseConfig else settings.sunsetConfig
-                if (!config.enabled) return@forEach
-                val trigger = event.dateTimeEpochMillis + config.offsetMinutes * 60 * 1000L
-                notificationScheduler.schedule(event.type, trigger, zoneId)
+            alarms.filter { it.enabled }.forEach { alarm ->
+                val baseTime = when (alarm.type) {
+                    SunEventType.SUNRISE -> times.sunrise
+                    SunEventType.SUNSET -> times.sunset
+                } ?: return@forEach
+                val trigger = baseTime.toInstant().toEpochMilli() + alarm.offsetMinutes * 60 * 1000L
+                notificationScheduler.schedule(
+                    alarmId = alarm.id,
+                    eventType = alarm.type,
+                    triggerAtMillis = trigger,
+                    zoneId = zoneId,
+                    label = alarm.label,
+                    offsetMinutes = alarm.offsetMinutes,
+                    date = date
+                )
             }
         }
     }

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/domain/model/Models.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/domain/model/Models.kt
@@ -2,8 +2,6 @@ package com.bfalls.suntimealerts.alarm.domain.model
 
 data class Coordinate(val latitude: Double, val longitude: Double)
 
-enum class SunEventType { SUNRISE, SUNSET }
-
 data class SunEvent(
     val dateEpochMillis: Long,
     val type: SunEventType,
@@ -28,5 +26,6 @@ data class UserSettings(
     val sunriseConfig: SunAlarmConfig,
     val sunsetConfig: SunAlarmConfig,
     val timeFormat24h: Boolean,
-    val onboardingComplete: Boolean
+    val onboardingComplete: Boolean,
+    val alarms: List<SunAlarm> = emptyList()
 )

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/domain/model/SunAlarm.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/domain/model/SunAlarm.kt
@@ -1,0 +1,31 @@
+package com.bfalls.suntimealerts.alarm.domain.model
+
+import java.util.UUID
+import kotlin.math.abs
+
+data class SunAlarm(
+    val id: String = UUID.randomUUID().toString(),
+    val type: SunEventType,
+    val offsetMinutes: Int,
+    val label: String,
+    val enabled: Boolean
+)
+
+fun formatOffset(offsetMinutes: Int): String {
+    if (offsetMinutes == 0) return "0m"
+
+    val sign = when {
+        offsetMinutes > 0 -> "+"
+        offsetMinutes < 0 -> "-"
+        else -> ""
+    }
+    val absoluteMinutes = abs(offsetMinutes)
+    val hours = absoluteMinutes / 60
+    val minutes = absoluteMinutes % 60
+
+    return if (hours > 0) {
+        "$sign${hours}h ${minutes}m"
+    } else {
+        "$sign${minutes}m"
+    }
+}

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/domain/model/SunEventType.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/domain/model/SunEventType.kt
@@ -1,0 +1,6 @@
+package com.bfalls.suntimealerts.alarm.domain.model
+
+enum class SunEventType {
+    SUNRISE,
+    SUNSET
+}

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/domain/service/SunArcPositionCalculator.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/domain/service/SunArcPositionCalculator.kt
@@ -1,0 +1,45 @@
+package com.bfalls.suntimealerts.alarm.domain.service
+
+import java.time.Duration
+import java.time.ZonedDateTime
+import kotlin.math.PI
+import kotlin.math.sin
+
+data class SunXY(val x: Float, val y: Float, val isDay: Boolean)
+
+object SunArcPositionCalculator {
+
+    fun computeSunT(now: ZonedDateTime, sunrise: ZonedDateTime?, sunset: ZonedDateTime?): Double {
+        if (sunrise == null || sunset == null) return -1.0
+        val totalMillis = Duration.between(sunrise, sunset).toMillis().coerceAtLeast(1)
+        val elapsedMillis = Duration.between(sunrise, now).toMillis().toDouble()
+        return elapsedMillis / totalMillis
+    }
+
+    fun computeArcScale(dayLengthMinutes: Long): Double {
+        val scale = dayLengthMinutes / (16.0 * 60.0)
+        return scale.coerceIn(0.35, 1.0)
+    }
+
+    fun computeSunXY(
+        t: Double,
+        width: Float,
+        horizonY: Float,
+        arcHeight: Float,
+        horizontalPadding: Float
+    ): SunXY {
+        val clamped = t.coerceIn(0.0, 1.0)
+        val isDay = t in 0.0..1.0
+        val x = lerp(horizontalPadding, width - horizontalPadding, clamped.toFloat())
+        val y = if (isDay) {
+            horizonY - arcHeight * sin(PI * clamped).toFloat()
+        } else {
+            horizonY + arcHeight * 0.35f
+        }
+        return SunXY(x, y, isDay)
+    }
+
+    private fun lerp(start: Float, end: Float, fraction: Float): Float {
+        return start + (end - start) * fraction
+    }
+}

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreen.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreen.kt
@@ -1,37 +1,570 @@
 package com.bfalls.suntimealerts.alarm.presentation.ui
 
+import android.widget.NumberPicker
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.bfalls.suntimealerts.alarm.domain.model.SunAlarm
+import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
+import com.bfalls.suntimealerts.alarm.domain.model.formatOffset
+import com.bfalls.suntimealerts.alarm.domain.service.SunArcPositionCalculator
+import com.bfalls.suntimealerts.alarm.domain.service.SunXY
 import com.bfalls.suntimealerts.alarm.presentation.viewmodel.HomeViewModel
+import kotlinx.coroutines.launch
+import java.time.Duration
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import kotlin.math.abs
+import kotlin.random.Random
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(viewModel: HomeViewModel) {
     val state by viewModel.state.collectAsState()
-    Scaffold { paddingValues ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-                .padding(16.dp)
-        ) {
-            Text(text = "Suntime Alerts")
-            Text(text = "Sunrise alarm")
-            Switch(checked = state.sunriseEnabled, onCheckedChange = viewModel::toggleSunrise)
-            Text(text = "Sunset alarm")
-            Switch(checked = state.sunsetEnabled, onCheckedChange = viewModel::toggleSunset)
-            Button(onClick = viewModel::reschedule) {
-                Text("Recompute & Reschedule")
+    val scope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+    var editingAlarm by remember { mutableStateOf<SunAlarm?>(null) }
+    var sheetType by remember { mutableStateOf(SunEventType.SUNRISE) }
+    var showSheet by remember { mutableStateOf(false) }
+
+    val openSheet: (SunAlarm?, SunEventType) -> Unit = { alarm, type ->
+        editingAlarm = alarm
+        sheetType = type
+        showSheet = true
+    }
+
+    Scaffold(
+        topBar = {
+            SunTopBar(
+                sunrise = state.sunriseTime,
+                sunset = state.sunsetTime,
+                onAdd = { openSheet(null, SunEventType.SUNRISE) }
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { openSheet(null, SunEventType.SUNRISE) }) {
+                Icon(Icons.Default.Add, contentDescription = "Add alarm")
+            }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { padding ->
+        if (state.isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                contentAlignment = Alignment.Center
+            ) {
+                Text("Loading…")
+            }
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                AlarmSection(
+                    title = "Sunrise",
+                    timeText = state.sunriseTimeText,
+                    alarms = state.sunriseAlarms,
+                    onAdd = { openSheet(null, SunEventType.SUNRISE) },
+                    onToggle = { alarm, enabled -> viewModel.toggleAlarmEnabled(alarm.id, enabled) },
+                    onEdit = { openSheet(it, it.type) },
+                    onDelete = { alarm ->
+                        viewModel.deleteAlarm(alarm.id)
+                        scope.launch {
+                            val result = snackbarHostState.showSnackbar(
+                                message = "Sunrise alarm deleted",
+                                actionLabel = "Undo"
+                            )
+                            if (result == SnackbarResult.ActionPerformed) {
+                                viewModel.restoreAlarm(alarm)
+                            }
+                        }
+                    },
+                    onDuplicate = { viewModel.duplicateAlarm(it.id) }
+                )
+                AlarmSection(
+                    title = "Sunset",
+                    timeText = state.sunsetTimeText,
+                    alarms = state.sunsetAlarms,
+                    onAdd = { openSheet(null, SunEventType.SUNSET) },
+                    onToggle = { alarm, enabled -> viewModel.toggleAlarmEnabled(alarm.id, enabled) },
+                    onEdit = { openSheet(it, it.type) },
+                    onDelete = { alarm ->
+                        viewModel.deleteAlarm(alarm.id)
+                        scope.launch {
+                            val result = snackbarHostState.showSnackbar(
+                                message = "Sunset alarm deleted",
+                                actionLabel = "Undo"
+                            )
+                            if (result == SnackbarResult.ActionPerformed) {
+                                viewModel.restoreAlarm(alarm)
+                            }
+                        }
+                    },
+                    onDuplicate = { viewModel.duplicateAlarm(it.id) }
+                )
             }
         }
+    }
+
+    if (showSheet) {
+        AlarmEditorSheet(
+            initialAlarm = editingAlarm,
+            defaultType = sheetType,
+            onDismiss = { showSheet = false },
+            onSave = { alarm ->
+                if (editingAlarm == null) {
+                    viewModel.addAlarm(alarm.type, alarm.offsetMinutes, alarm.label, alarm.enabled)
+                } else {
+                    viewModel.updateAlarm(alarm)
+                }
+                showSheet = false
+            }
+        )
+    }
+}
+
+@Composable
+private fun ColumnScope.AlarmSection(
+    title: String,
+    timeText: String?,
+    alarms: List<SunAlarm>,
+    onAdd: () -> Unit,
+    onToggle: (SunAlarm, Boolean) -> Unit,
+    onEdit: (SunAlarm) -> Unit,
+    onDelete: (SunAlarm) -> Unit,
+    onDuplicate: (SunAlarm) -> Unit
+) {
+    val listHeight = LocalConfiguration.current.screenHeightDp.dp / 2
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column {
+                Text(text = title, fontWeight = FontWeight.Bold)
+                timeText?.let { Text(text = it, color = Color.Gray) }
+            }
+            TextButton(onClick = onAdd) {
+                Text(text = "Add")
+            }
+        }
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 120.dp, max = listHeight)
+        ) {
+            items(alarms, key = { it.id }) { alarm ->
+                AlarmRow(
+                    alarm = alarm,
+                    onToggle = { enabled -> onToggle(alarm, enabled) },
+                    onEdit = { onEdit(alarm) },
+                    onDelete = { onDelete(alarm) },
+                    onDuplicate = { onDuplicate(alarm) }
+                )
+            }
+            if (alarms.isEmpty()) {
+                item {
+                    TextButton(onClick = onAdd) {
+                        Text("No alarms yet. Add one?")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlarmRow(
+    alarm: SunAlarm,
+    onToggle: (Boolean) -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+    onDuplicate: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onEdit() }
+            .padding(vertical = 8.dp)
+    ) {
+        Column(modifier = Modifier.align(Alignment.CenterStart)) {
+            Text(
+                text = formatOffset(alarm.offsetMinutes),
+                fontWeight = FontWeight.Bold
+            )
+            if (alarm.label.isNotBlank()) {
+                Text(
+                    text = alarm.label,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+        Row(
+            modifier = Modifier.align(Alignment.CenterEnd),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = onDuplicate) {
+                Icon(Icons.Default.ContentCopy, contentDescription = "Duplicate alarm")
+            }
+            IconButton(onClick = onDelete) {
+                Icon(Icons.Default.Delete, contentDescription = "Delete alarm")
+            }
+            Switch(
+                checked = alarm.enabled,
+                onCheckedChange = onToggle
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AlarmEditorSheet(
+    initialAlarm: SunAlarm?,
+    defaultType: SunEventType,
+    onDismiss: () -> Unit,
+    onSave: (SunAlarm) -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var type by rememberSaveable { mutableStateOf(initialAlarm?.type ?: defaultType) }
+    var isAfter by rememberSaveable { mutableStateOf((initialAlarm?.offsetMinutes ?: 0) >= 0) }
+    var hours by rememberSaveable { mutableStateOf(abs(initialAlarm?.offsetMinutes ?: 0) / 60) }
+    var minutes by rememberSaveable { mutableStateOf(abs(initialAlarm?.offsetMinutes ?: 0) % 60) }
+    var label by rememberSaveable { mutableStateOf(initialAlarm?.label ?: "") }
+    var enabled by rememberSaveable { mutableStateOf(initialAlarm?.enabled ?: true) }
+
+    LaunchedEffect(initialAlarm?.id, defaultType) {
+        type = initialAlarm?.type ?: defaultType
+        val offset = initialAlarm?.offsetMinutes ?: 0
+        isAfter = offset >= 0
+        hours = abs(offset) / 60
+        minutes = abs(offset) % 60
+        label = initialAlarm?.label ?: ""
+        enabled = initialAlarm?.enabled ?: true
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(text = if (initialAlarm == null) "Add alarm" else "Edit alarm", fontWeight = FontWeight.Bold)
+            Text(text = "Event")
+            SingleChoiceSegmentedButtonRow {
+                SegmentedButton(
+                    selected = type == SunEventType.SUNRISE,
+                    onClick = { type = SunEventType.SUNRISE },
+                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2)
+                ) {
+                    Text("Sunrise")
+                }
+                SegmentedButton(
+                    selected = type == SunEventType.SUNSET,
+                    onClick = { type = SunEventType.SUNSET },
+                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2)
+                ) {
+                    Text("Sunset")
+                }
+            }
+            Text(text = "Timing")
+            SingleChoiceSegmentedButtonRow {
+                SegmentedButton(
+                    selected = !isAfter,
+                    onClick = { isAfter = false },
+                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2)
+                ) {
+                    Text("Before")
+                }
+                SegmentedButton(
+                    selected = isAfter,
+                    onClick = { isAfter = true },
+                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2)
+                ) {
+                    Text("After")
+                }
+            }
+            OffsetPicker(
+                hours = hours,
+                minutes = minutes,
+                onHoursChanged = { hours = it },
+                onMinutesChanged = { minutes = it }
+            )
+            TextField(
+                value = label,
+                onValueChange = { label = it },
+                label = { Text("Label") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text("Enabled")
+                Switch(checked = enabled, onCheckedChange = { enabled = it })
+            }
+            Button(
+                onClick = {
+                    val totalMinutes = hours * 60 + minutes
+                    val offset = if (isAfter) totalMinutes else -totalMinutes
+                    val updated = initialAlarm?.copy(
+                        type = type,
+                        offsetMinutes = offset,
+                        label = label,
+                        enabled = enabled
+                    ) ?: SunAlarm(
+                        type = type,
+                        offsetMinutes = offset,
+                        label = label,
+                        enabled = enabled
+                    )
+                    onSave(updated)
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Save")
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+    }
+}
+
+@Composable
+private fun OffsetPicker(
+    hours: Int,
+    minutes: Int,
+    onHoursChanged: (Int) -> Unit,
+    onMinutesChanged: (Int) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceEvenly
+    ) {
+        NumberPickerColumn(
+            label = "Hours",
+            value = hours,
+            range = 0..23,
+            onValueChange = onHoursChanged
+        )
+        NumberPickerColumn(
+            label = "Minutes",
+            value = minutes,
+            range = 0..59,
+            onValueChange = onMinutesChanged
+        )
+    }
+}
+
+@Composable
+private fun NumberPickerColumn(
+    label: String,
+    value: Int,
+    range: IntRange,
+    onValueChange: (Int) -> Unit
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(text = label, fontWeight = FontWeight.Bold)
+        AndroidView(
+            factory = { context ->
+                NumberPicker(context).apply {
+                    minValue = range.first
+                    maxValue = range.last
+                    setOnValueChangedListener { _, _, newVal -> onValueChange(newVal) }
+                }
+            },
+            update = {
+                if (it.value != value) {
+                    it.value = value.coerceIn(range)
+                }
+            }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SunTopBar(
+    sunrise: ZonedDateTime?,
+    sunset: ZonedDateTime?,
+    onAdd: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(200.dp)
+    ) {
+        SunAppBarBackground(
+            sunrise = sunrise,
+            sunset = sunset,
+            modifier = Modifier
+                .matchParentSize()
+                .testTag("sun_appbar_background")
+        )
+        TopAppBar(
+            title = { Text("Sun Alarms") },
+            actions = {
+                IconButton(onClick = onAdd) {
+                    Icon(Icons.Default.Add, contentDescription = "Add alarm")
+                }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = Color.Transparent,
+                scrolledContainerColor = Color.Transparent,
+                titleContentColor = Color.White,
+                actionIconContentColor = Color.White
+            )
+        )
+    }
+}
+
+@Composable
+private fun SunAppBarBackground(
+    sunrise: ZonedDateTime?,
+    sunset: ZonedDateTime?,
+    modifier: Modifier = Modifier
+) {
+    val zone = sunrise?.zone ?: sunset?.zone ?: ZoneId.systemDefault()
+    val now = ZonedDateTime.now(zone)
+    Canvas(modifier = modifier) {
+        val dayLengthMinutes = if (sunrise != null && sunset != null) {
+            Duration.between(sunrise, sunset).toMinutes()
+        } else {
+            12L * 60
+        }
+        val arcScale = SunArcPositionCalculator.computeArcScale(dayLengthMinutes)
+        val horizonY = size.height * 0.75f
+        val arcHeight = size.height * 0.45f * arcScale.toFloat()
+        val t = SunArcPositionCalculator.computeSunT(now, sunrise, sunset)
+        val sunPosition: SunXY = SunArcPositionCalculator.computeSunXY(
+            t = t,
+            width = size.width,
+            horizonY = horizonY,
+            arcHeight = arcHeight,
+            horizontalPadding = size.width * 0.1f
+        )
+        val isDay = sunPosition.isDay && sunrise != null && sunset != null
+        val gradient = if (isDay) {
+            Brush.verticalGradient(
+                listOf(
+                    Color(0xFF64B5F6),
+                    Color(0xFFBBDEFB)
+                )
+            )
+        } else {
+            Brush.verticalGradient(
+                listOf(
+                    Color(0xFF0D1B2A),
+                    Color(0xFF001219)
+                )
+            )
+        }
+        drawRect(brush = gradient, size = size)
+
+        if (!isDay) {
+            drawStars(horizonY, now.toLocalDate().toEpochDay())
+        }
+
+        drawLine(
+            color = Color.White.copy(alpha = 0.25f),
+            start = Offset(0f, horizonY),
+            end = Offset(size.width, horizonY),
+            strokeWidth = 2f
+        )
+
+        if (isDay) {
+            drawCircle(
+                color = Color(0xFFFFD54F),
+                radius = size.minDimension * 0.06f,
+                center = Offset(sunPosition.x, sunPosition.y)
+            )
+        }
+    }
+}
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawStars(
+    horizonY: Float,
+    seed: Long
+) {
+    val random = Random(seed)
+    repeat(60) {
+        val x = random.nextFloat() * size.width
+        val y = random.nextFloat() * (horizonY * 0.9f)
+        val radius = (random.nextDouble(1.0, 3.0)).toFloat()
+        drawCircle(
+            color = Color.White.copy(alpha = random.nextFloat().coerceIn(0.3f, 0.8f)),
+            radius = radius,
+            center = Offset(x, y)
+        )
     }
 }

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/HomeViewModel.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/HomeViewModel.kt
@@ -7,55 +7,169 @@ import com.bfalls.suntimealerts.alarm.data.SettingsRepository
 import com.bfalls.suntimealerts.alarm.data.SunScheduler
 import com.bfalls.suntimealerts.alarm.domain.model.Coordinate
 import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
+import com.bfalls.suntimealerts.alarm.domain.model.SunAlarm
+import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
+import com.bfalls.suntimealerts.alarm.domain.model.UserSettings
+import com.bfalls.suntimealerts.alarm.domain.service.SunTimesCalculator
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import java.time.LocalDate
 import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.util.UUID
 
 class HomeViewModel(
     private val locationService: LocationProvider,
     private val settingsStore: SettingsRepository,
-    private val scheduleService: SunScheduler
+    private val scheduleService: SunScheduler,
+    private val sunTimesCalculator: SunTimesCalculator
 ) : ViewModel() {
 
     data class State(
-        val sunrise: String? = null,
-        val sunset: String? = null,
-        val sunriseEnabled: Boolean = true,
-        val sunsetEnabled: Boolean = false
+        val isLoading: Boolean = true,
+        val sunriseTime: ZonedDateTime? = null,
+        val sunsetTime: ZonedDateTime? = null,
+        val sunriseTimeText: String? = null,
+        val sunsetTimeText: String? = null,
+        val sunriseAlarms: List<SunAlarm> = emptyList(),
+        val sunsetAlarms: List<SunAlarm> = emptyList(),
+        val error: String? = null
     )
 
     private val _state = MutableStateFlow(State())
     val state: StateFlow<State> = _state
 
+    private var cachedSettings: UserSettings? = null
+
     init {
-        viewModelScope.launch { load() }
+        viewModelScope.launch { loadState() }
     }
 
-    private suspend fun load() {
-        val settings = settingsStore.load()
-        _state.value = _state.value.copy(
-            sunriseEnabled = settings.sunriseConfig.enabled,
-            sunsetEnabled = settings.sunsetConfig.enabled
-        )
+    fun addAlarm(
+        type: SunEventType,
+        offsetMinutes: Int,
+        label: String,
+        enabled: Boolean
+    ) {
+        viewModelScope.launch {
+            val current = _state.value
+            val newAlarm = SunAlarm(
+                id = UUID.randomUUID().toString(),
+                type = type,
+                offsetMinutes = offsetMinutes,
+                label = label,
+                enabled = enabled
+            )
+            persistAlarms(current.allAlarms() + newAlarm)
+        }
     }
 
-    fun toggleSunrise(enabled: Boolean) {
-        _state.value = _state.value.copy(sunriseEnabled = enabled)
+    fun updateAlarm(alarm: SunAlarm) {
+        viewModelScope.launch {
+            val updated = _state.value.allAlarms().map {
+                if (it.id == alarm.id) alarm else it
+            }
+            persistAlarms(updated)
+        }
     }
 
-    fun toggleSunset(enabled: Boolean) {
-        _state.value = _state.value.copy(sunsetEnabled = enabled)
+    fun toggleAlarmEnabled(id: String, enabled: Boolean) {
+        viewModelScope.launch {
+            val updated = _state.value.allAlarms().map {
+                if (it.id == id) it.copy(enabled = enabled) else it
+            }
+            persistAlarms(updated)
+        }
+    }
+
+    fun deleteAlarm(id: String) {
+        viewModelScope.launch {
+            val updated = _state.value.allAlarms().filterNot { it.id == id }
+            persistAlarms(updated)
+        }
+    }
+
+    fun duplicateAlarm(id: String) {
+        viewModelScope.launch {
+            val current = _state.value.allAlarms()
+            val toCopy = current.firstOrNull { it.id == id } ?: return@launch
+            val copy = toCopy.copy(
+                id = UUID.randomUUID().toString(),
+                label = if (toCopy.label.isNotBlank()) "${toCopy.label} (copy)" else toCopy.label
+            )
+            persistAlarms(current + copy)
+        }
+    }
+
+    fun restoreAlarm(alarm: SunAlarm) {
+        viewModelScope.launch {
+            val existing = _state.value.allAlarms().filterNot { it.id == alarm.id }
+            persistAlarms(existing + alarm)
+        }
     }
 
     fun reschedule() {
         viewModelScope.launch {
-            val settings = settingsStore.load()
-            val coordinate = when (settings.locationMode) {
-                LocationMode.FIXED -> settings.fixedLocation ?: locationService.currentCoordinate()
-                LocationMode.DEVICE -> locationService.currentCoordinate()
-            } ?: Coordinate(0.0, 0.0)
-            scheduleService.schedule(coordinate, ZoneId.systemDefault())
+            scheduleForCurrentSettings()
         }
     }
+
+    private suspend fun loadState() {
+        val settings = settingsStore.load()
+        cachedSettings = settings
+        val alarms = settings.alarms.ifEmpty { settingsStore.loadAlarms() }
+        if (settings.alarms.isEmpty()) {
+            settingsStore.saveAlarms(alarms)
+        }
+        val zoneId = ZoneId.systemDefault()
+        val coordinate = resolveCoordinate(settings)
+        val sunTimes = coordinate?.let {
+            sunTimesCalculator.calculateSunTimes(LocalDate.now(zoneId), it, zoneId)
+        }
+        _state.value = State(
+            isLoading = false,
+            sunriseTime = sunTimes?.sunrise,
+            sunsetTime = sunTimes?.sunset,
+            sunriseTimeText = formatTime(sunTimes?.sunrise, settings.timeFormat24h),
+            sunsetTimeText = formatTime(sunTimes?.sunset, settings.timeFormat24h),
+            sunriseAlarms = alarms.filter { it.type == SunEventType.SUNRISE }.sortedBy { it.offsetMinutes },
+            sunsetAlarms = alarms.filter { it.type == SunEventType.SUNSET }.sortedBy { it.offsetMinutes },
+            error = if (coordinate == null) "Location unavailable" else null
+        )
+
+        scheduleForCurrentSettings()
+    }
+
+    private fun formatTime(dateTime: ZonedDateTime?, use24h: Boolean): String? {
+        dateTime ?: return null
+        val pattern = if (use24h) "HH:mm" else "h:mm a"
+        return dateTime.format(DateTimeFormatter.ofPattern(pattern))
+    }
+
+    private suspend fun persistAlarms(alarms: List<SunAlarm>) {
+        settingsStore.saveAlarms(alarms)
+        cachedSettings = (cachedSettings ?: settingsStore.load()).copy(alarms = alarms)
+        _state.value = _state.value.copy(
+            sunriseAlarms = alarms.filter { it.type == SunEventType.SUNRISE }.sortedBy { it.offsetMinutes },
+            sunsetAlarms = alarms.filter { it.type == SunEventType.SUNSET }.sortedBy { it.offsetMinutes }
+        )
+        scheduleForCurrentSettings()
+    }
+
+    private suspend fun scheduleForCurrentSettings() {
+        val settings = cachedSettings ?: settingsStore.load()
+        val coordinate = resolveCoordinate(settings) ?: Coordinate(0.0, 0.0)
+        scheduleService.schedule(coordinate, ZoneId.systemDefault())
+    }
+
+    private suspend fun resolveCoordinate(settings: UserSettings): Coordinate? {
+        return when (settings.locationMode) {
+            LocationMode.FIXED -> settings.fixedLocation ?: locationService.currentCoordinate()
+            LocationMode.DEVICE -> locationService.currentCoordinate()
+        }
+    }
+
+    private fun State.allAlarms(): List<SunAlarm> = sunriseAlarms + sunsetAlarms
 }

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/OnboardingViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.bfalls.suntimealerts.alarm.data.LocationProvider
 import com.bfalls.suntimealerts.alarm.data.SettingsRepository
 import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
+import com.bfalls.suntimealerts.alarm.domain.model.SunAlarm
 import com.bfalls.suntimealerts.alarm.domain.model.SunAlarmConfig
 import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
 import com.bfalls.suntimealerts.cities.data.City
@@ -214,23 +215,44 @@ class OnboardingViewModel(
     fun complete(onFinished: () -> Unit) {
         viewModelScope.launch {
             var settings = settingsStore.load()
+            val existingAlarmsByType = settings.alarms.associateBy { it.type }
+            val onboardingState = _state.value
+            val updatedAlarms = listOf(
+                SunAlarm(
+                    id = existingAlarmsByType[SunEventType.SUNRISE]?.id ?: existingAlarmsByType.values.firstOrNull { it.type == SunEventType.SUNRISE }?.id
+                    ?: java.util.UUID.randomUUID().toString(),
+                    type = SunEventType.SUNRISE,
+                    offsetMinutes = onboardingState.sunriseOffsetMinutes,
+                    label = existingAlarmsByType[SunEventType.SUNRISE]?.label ?: "Sunrise",
+                    enabled = onboardingState.notificationsEnabled && onboardingState.sunriseEnabled
+                ),
+                SunAlarm(
+                    id = existingAlarmsByType[SunEventType.SUNSET]?.id ?: existingAlarmsByType.values.firstOrNull { it.type == SunEventType.SUNSET }?.id
+                    ?: java.util.UUID.randomUUID().toString(),
+                    type = SunEventType.SUNSET,
+                    offsetMinutes = onboardingState.sunsetOffsetMinutes,
+                    label = existingAlarmsByType[SunEventType.SUNSET]?.label ?: "Sunset",
+                    enabled = onboardingState.notificationsEnabled && onboardingState.sunsetEnabled
+                )
+            )
             settings = settings.copy(
                 locationMode = if (_state.value.locationMode == LocationMode.FIXED) LocationMode.FIXED else LocationMode.DEVICE,
                 sunriseConfig = SunAlarmConfig(
-                    enabled = _state.value.notificationsEnabled && _state.value.sunriseEnabled,
+                    enabled = onboardingState.notificationsEnabled && onboardingState.sunriseEnabled,
                     eventType = SunEventType.SUNRISE,
-                    offsetMinutes = _state.value.sunriseOffsetMinutes
+                    offsetMinutes = onboardingState.sunriseOffsetMinutes
                 ),
                 sunsetConfig = SunAlarmConfig(
-                    enabled = _state.value.notificationsEnabled && _state.value.sunsetEnabled,
+                    enabled = onboardingState.notificationsEnabled && onboardingState.sunsetEnabled,
                     eventType = SunEventType.SUNSET,
-                    offsetMinutes = _state.value.sunsetOffsetMinutes
+                    offsetMinutes = onboardingState.sunsetOffsetMinutes
                 ),
-                onboardingComplete = true
+                onboardingComplete = true,
+                alarms = updatedAlarms
             )
             if (settings.locationMode == LocationMode.FIXED) {
-                val lat = _state.value.fixedLatitude.toDoubleOrNull() ?: 0.0
-                val lon = _state.value.fixedLongitude.toDoubleOrNull() ?: 0.0
+                val lat = onboardingState.fixedLatitude.toDoubleOrNull() ?: 0.0
+                val lon = onboardingState.fixedLongitude.toDoubleOrNull() ?: 0.0
                 settings = settings.copy(
                     fixedLocation = com.bfalls.suntimealerts.alarm.domain.model.Coordinate(
                         lat,

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/services/NotificationScheduler.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/services/NotificationScheduler.kt
@@ -1,47 +1,148 @@
 package com.bfalls.suntimealerts.alarm.services
 
 import android.app.AlarmManager
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-//import androidx.privacysandbox.tools.core.model.Type
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
+import com.bfalls.suntimealerts.alarm.domain.model.formatOffset
+import java.time.LocalDate
 import java.time.ZoneId
+import java.util.UUID
+import kotlin.math.abs
 
-class NotificationScheduler(private val context: Context) {
+interface AlarmScheduler {
+    fun schedule(
+        alarmId: String,
+        eventType: SunEventType,
+        triggerAtMillis: Long,
+        zoneId: ZoneId,
+        label: String,
+        offsetMinutes: Int,
+        date: LocalDate
+    )
+
+    fun cancelAll()
+}
+
+class NotificationScheduler(private val context: Context) : AlarmScheduler {
     private val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    private val prefs = context.getSharedPreferences("sun_alarm_requests", Context.MODE_PRIVATE)
+    private val requestCodesKey = "request_codes"
+    private val channelId = "sun_event_channel"
 
-    fun schedule(eventType: SunEventType, triggerAtMillis: Long, zoneId: ZoneId) {
+    override fun schedule(
+        alarmId: String,
+        eventType: SunEventType,
+        triggerAtMillis: Long,
+        zoneId: ZoneId,
+        label: String,
+        offsetMinutes: Int,
+        date: LocalDate
+    ) {
         val intent = Intent(context, SunEventReceiver::class.java).apply {
             putExtra("type", eventType.name)
+            putExtra("alarmId", alarmId)
+            putExtra("label", label)
+            putExtra("offsetMinutes", offsetMinutes)
+            putExtra("zoneId", zoneId.id)
         }
-        val pending = PendingIntent.getBroadcast(context, eventType.ordinal, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        val requestCode = requestCode(alarmId, date)
+        val pending = PendingIntent.getBroadcast(
+            context,
+            requestCode,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
         alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pending)
+        rememberRequestCode(requestCode)
     }
 
-    fun cancelAll() {
-        SunEventType.values().forEach { type ->
-            cancel(type)
-        }
+    override fun cancelAll() {
+        val codes = loadRequestCodes()
+        codes.forEach { cancel(it) }
+        prefs.edit().remove(requestCodesKey).apply()
     }
 
-    fun cancel(eventType: SunEventType) {
+    private fun cancel(requestCode: Int) {
         val intent = Intent(context, SunEventReceiver::class.java).apply {
-            putExtra("type", eventType.name)
+            action = "CANCEL"
         }
         val pending = PendingIntent.getBroadcast(
             context,
-            eventType.ordinal,
+            requestCode,
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
         alarmManager.cancel(pending)
     }
+
+    private fun rememberRequestCode(code: Int) {
+        val updated = loadRequestCodes().apply { add(code) }.map { it.toString() }.toSet()
+        prefs.edit().putStringSet(requestCodesKey, updated).apply()
+    }
+
+    private fun loadRequestCodes(): MutableSet<Int> {
+        return prefs.getStringSet(requestCodesKey, emptySet())
+            ?.mapNotNull { it.toIntOrNull() }
+            ?.toMutableSet()
+            ?: mutableSetOf()
+    }
+
+    private fun requestCode(alarmId: String, date: LocalDate): Int {
+        return abs((alarmId + date.toString()).hashCode())
+    }
 }
 
 class SunEventReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        // TODO: build user-visible notification; placeholder for scaffold
+        val typeValue = intent.getStringExtra("type") ?: return
+        val eventType = runCatching { SunEventType.valueOf(typeValue) }.getOrNull() ?: return
+        val offsetMinutes = intent.getIntExtra("offsetMinutes", 0)
+        val label = intent.getStringExtra("label").orEmpty()
+        val alarmId = intent.getStringExtra("alarmId") ?: UUID.randomUUID().toString()
+
+        val channelId = "sun_event_channel"
+        val notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                channelId,
+                "Sun alarms",
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        val title = if (eventType == SunEventType.SUNRISE) "Sunrise alarm" else "Sunset alarm"
+        val timingWord = when {
+            offsetMinutes < 0 -> "before"
+            offsetMinutes > 0 -> "after"
+            else -> "at"
+        }
+        val anchor = if (eventType == SunEventType.SUNRISE) "sunrise" else "sunset"
+        val offsetText = formatOffset(offsetMinutes)
+        val body = buildString {
+            if (label.isNotBlank()) {
+                append(label).append(" • ")
+            }
+            append(offsetText).append(" ").append(timingWord).append(" ").append(anchor)
+        }
+
+        val notification = NotificationCompat.Builder(context, channelId)
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+            .setAutoCancel(true)
+            .build()
+
+        NotificationManagerCompat.from(context).notify(alarmId.hashCode(), notification)
     }
 }

--- a/android/app/src/test/java/com/bfalls/suntimealerts/alarm/data/SettingsStoreTest.kt
+++ b/android/app/src/test/java/com/bfalls/suntimealerts/alarm/data/SettingsStoreTest.kt
@@ -1,0 +1,28 @@
+package com.bfalls.suntimealerts.alarm.data
+
+import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SettingsStoreTest {
+
+    @Test
+    fun migratesLegacyConfigsIntoAlarms() {
+        val alarms = migrateLegacyAlarms(
+            sunriseEnabled = true,
+            sunriseOffset = 15,
+            sunsetEnabled = false,
+            sunsetOffset = -30
+        )
+
+        assertEquals(2, alarms.size)
+        val sunrise = alarms.first { it.type == SunEventType.SUNRISE }
+        val sunset = alarms.first { it.type == SunEventType.SUNSET }
+        assertEquals(15, sunrise.offsetMinutes)
+        assertTrue(sunrise.enabled)
+        assertEquals(-30, sunset.offsetMinutes)
+        assertFalse(sunset.enabled)
+    }
+}

--- a/android/app/src/test/java/com/bfalls/suntimealerts/alarm/data/SunScheduleServiceTest.kt
+++ b/android/app/src/test/java/com/bfalls/suntimealerts/alarm/data/SunScheduleServiceTest.kt
@@ -1,0 +1,83 @@
+package com.bfalls.suntimealerts.alarm.data
+
+import com.bfalls.suntimealerts.alarm.domain.model.Coordinate
+import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
+import com.bfalls.suntimealerts.alarm.domain.model.SunAlarm
+import com.bfalls.suntimealerts.alarm.domain.model.SunAlarmConfig
+import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
+import com.bfalls.suntimealerts.alarm.domain.model.UserSettings
+import com.bfalls.suntimealerts.alarm.domain.service.SunTimesCalculator
+import com.bfalls.suntimealerts.alarm.services.AlarmScheduler
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneId
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SunScheduleServiceTest {
+
+    @Test
+    fun schedulesWithOffsetApplied() = runTest {
+        val calculator = SunTimesCalculator()
+        val notificationScheduler = RecordingNotificationScheduler()
+        val repo = object : SettingsRepository {
+            override suspend fun load(): UserSettings = UserSettings(
+                locationMode = LocationMode.DEVICE,
+                sunriseConfig = SunAlarmConfig(true, SunEventType.SUNRISE, 0),
+                sunsetConfig = SunAlarmConfig(true, SunEventType.SUNSET, 0),
+                timeFormat24h = true,
+                onboardingComplete = true,
+                alarms = alarms
+            )
+
+            override suspend fun save(settings: UserSettings) = Unit
+            override suspend fun loadAlarms(): List<SunAlarm> = alarms
+            override suspend fun saveAlarms(alarms: List<SunAlarm>) = Unit
+
+            private val alarms = listOf(
+                SunAlarm(
+                    type = SunEventType.SUNRISE,
+                    offsetMinutes = 30,
+                    label = "Morning walk",
+                    enabled = true
+                )
+            )
+        }
+        val service = SunScheduleService(calculator, repo, notificationScheduler)
+        val coordinate = Coordinate(0.0, 0.0)
+        val zone = ZoneId.of("UTC")
+
+        service.schedule(coordinate, zone)
+
+        val today = LocalDate.now(zone)
+        val sunTimes = calculator.calculateSunTimes(today, coordinate, zone)
+        val expectedTrigger = requireNotNull(sunTimes.sunrise).toInstant().toEpochMilli() + 30 * 60 * 1000L
+
+        assertTrue(
+            notificationScheduler.entries.any {
+                it.eventType == SunEventType.SUNRISE &&
+                    it.triggerAtMillis == expectedTrigger
+            }
+        )
+    }
+
+    private class RecordingNotificationScheduler : AlarmScheduler {
+        data class Entry(
+            val alarmId: String,
+            val eventType: SunEventType,
+            val triggerAtMillis: Long
+        )
+
+        val entries = mutableListOf<Entry>()
+
+        override fun schedule(alarmId: String, eventType: SunEventType, triggerAtMillis: Long, zoneId: ZoneId, label: String, offsetMinutes: Int, date: LocalDate) {
+            entries += Entry(alarmId, eventType, triggerAtMillis)
+        }
+
+        override fun cancelAll() {
+            entries.clear()
+        }
+    }
+}

--- a/android/app/src/test/java/com/bfalls/suntimealerts/alarm/domain/service/SunArcPositionCalculatorTest.kt
+++ b/android/app/src/test/java/com/bfalls/suntimealerts/alarm/domain/service/SunArcPositionCalculatorTest.kt
@@ -1,0 +1,67 @@
+package com.bfalls.suntimealerts.alarm.domain.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class SunArcPositionCalculatorTest {
+
+    @Test
+    fun middayRisesAboveHorizon() {
+        val zone = ZoneId.of("UTC")
+        val sunrise = ZonedDateTime.of(2024, 6, 1, 6, 0, 0, 0, zone)
+        val sunset = ZonedDateTime.of(2024, 6, 1, 18, 0, 0, 0, zone)
+        val noon = ZonedDateTime.of(2024, 6, 1, 12, 0, 0, 0, zone)
+        val t = SunArcPositionCalculator.computeSunT(noon, sunrise, sunset)
+        val position = SunArcPositionCalculator.computeSunXY(
+            t = t,
+            width = 400f,
+            horizonY = 200f,
+            arcHeight = 80f,
+            horizontalPadding = 20f
+        )
+
+        assertTrue(position.isDay)
+        assertEquals(200f, position.y + 80f, 0.5f) // near peak
+        val sunrisePos = SunArcPositionCalculator.computeSunXY(
+            t = 0.0,
+            width = 400f,
+            horizonY = 200f,
+            arcHeight = 80f,
+            horizontalPadding = 20f
+        )
+        assertTrue(position.y < sunrisePos.y)
+    }
+
+    @Test
+    fun arcScaleReflectsSeason() {
+        val winter = SunArcPositionCalculator.computeArcScale(8 * 60L)
+        val summer = SunArcPositionCalculator.computeArcScale(15 * 60L)
+
+        assertTrue(winter < summer)
+        assertTrue(winter >= 0.35)
+        assertTrue(summer <= 1.0)
+    }
+
+    @Test
+    fun nightPlacesSunBelowHorizon() {
+        val zone = ZoneId.of("UTC")
+        val sunrise = ZonedDateTime.of(2024, 6, 1, 6, 0, 0, 0, zone)
+        val sunset = ZonedDateTime.of(2024, 6, 1, 18, 0, 0, 0, zone)
+        val night = ZonedDateTime.of(2024, 6, 1, 2, 0, 0, 0, zone)
+        val t = SunArcPositionCalculator.computeSunT(night, sunrise, sunset)
+        val position = SunArcPositionCalculator.computeSunXY(
+            t = t,
+            width = 300f,
+            horizonY = 180f,
+            arcHeight = 80f,
+            horizontalPadding = 20f
+        )
+
+        assertFalse(position.isDay)
+        assertTrue(position.y > 180f)
+    }
+}

--- a/android/app/src/test/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/HomeViewModelTest.kt
+++ b/android/app/src/test/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/HomeViewModelTest.kt
@@ -6,9 +6,11 @@ import com.bfalls.suntimealerts.alarm.data.SettingsRepository
 import com.bfalls.suntimealerts.alarm.data.SunScheduler
 import com.bfalls.suntimealerts.alarm.domain.model.Coordinate
 import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
+import com.bfalls.suntimealerts.alarm.domain.model.SunAlarm
 import com.bfalls.suntimealerts.alarm.domain.model.SunAlarmConfig
 import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
 import com.bfalls.suntimealerts.alarm.domain.model.UserSettings
+import com.bfalls.suntimealerts.alarm.domain.service.SunTimesCalculator
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -32,27 +34,44 @@ class HomeViewModelTest {
             sunriseConfig = SunAlarmConfig(enabled = true, eventType = SunEventType.SUNRISE, offsetMinutes = 0),
             sunsetConfig = SunAlarmConfig(enabled = false, eventType = SunEventType.SUNSET, offsetMinutes = 0),
             timeFormat24h = true,
-            onboardingComplete = true
+            onboardingComplete = true,
+            alarms = listOf(
+                SunAlarm(
+                    type = SunEventType.SUNRISE,
+                    offsetMinutes = 0,
+                    label = "Morning",
+                    enabled = true
+                )
+            )
         )
-        val settingsRepo = FakeSettingsRepository(settings)
+        val settingsRepo = FakeSettingsRepository(settings, settings.alarms)
         val locationProvider = RecordingLocationProvider()
         val scheduler = RecordingScheduler()
 
-        val viewModel = HomeViewModel(locationProvider, settingsRepo, scheduler)
+        val viewModel = HomeViewModel(locationProvider, settingsRepo, scheduler, SunTimesCalculator())
 
         advanceUntilIdle()
         viewModel.reschedule()
         advanceUntilIdle()
 
-        assertEquals(listOf(fixedCoordinate), scheduler.receivedCoordinates)
+        assertEquals(listOf(fixedCoordinate, fixedCoordinate), scheduler.receivedCoordinates)
         assertEquals(0, locationProvider.requestCount)
     }
 
     private class FakeSettingsRepository(
-        private val settings: UserSettings
+        private var settings: UserSettings,
+        private var alarms: List<SunAlarm>
     ) : SettingsRepository {
-        override suspend fun load(): UserSettings = settings
-        override suspend fun save(settings: UserSettings) = Unit
+        override suspend fun load(): UserSettings = settings.copy(alarms = alarms)
+        override suspend fun save(settings: UserSettings) {
+            this.settings = settings
+        }
+
+        override suspend fun loadAlarms(): List<SunAlarm> = alarms
+
+        override suspend fun saveAlarms(alarms: List<SunAlarm>) {
+            this.alarms = alarms
+        }
     }
 
     private class RecordingLocationProvider(


### PR DESCRIPTION
- Added a SunAlarm domain model with DataStore-backed alarm list APIs and migration from legacy sunrise/sunset settings.
- Updated scheduling to iterate all enabled alarms for today and tomorrow while coordinating with an AlarmScheduler that issues unique, contextual notifications.
- Rebuilt the home screen into a clock-style alarms UI with separate sunrise/sunset lists, offset/label editor sheet, and a sun-arc app bar background driven by new sun-position math.
- Added coverage for migration, scheduling offsets, sun-arc calculations, and UI wiring via new unit and Compose UI tests.