### PR TITLE
Add new domain models for alarms

### DIFF
--- a/android/app/src/androidTest/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreenAppBarTest.kt
+++ b/android/app/src/androidTest/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreenAppBarTest.kt
@@ -1,85 +1,76 @@
 package com.bfalls.suntimealerts.alarm.presentation.ui
 
 import androidx.activity.ComponentActivity
-import androidx.compose.ui.test.assertExists
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import com.bfalls.suntimealerts.alarm.data.LocationProvider
-import com.bfalls.suntimealerts.alarm.data.SettingsRepository
-import com.bfalls.suntimealerts.alarm.data.SunScheduler
-import com.bfalls.suntimealerts.alarm.domain.model.Coordinate
-import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.bfalls.suntimealerts.alarm.domain.model.SunAlarm
-import com.bfalls.suntimealerts.alarm.domain.model.SunAlarmConfig
 import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
-import com.bfalls.suntimealerts.alarm.domain.model.UserSettings
-import com.bfalls.suntimealerts.alarm.domain.service.SunTimesCalculator
+import com.bfalls.suntimealerts.alarm.domain.model.formatOffset
+import com.bfalls.suntimealerts.alarm.presentation.viewmodel.HomeViewModel
 import com.bfalls.suntimealerts.ui.theme.SuntimeAlertsTheme
-import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 import java.time.ZoneId
+import java.time.ZonedDateTime
 
+@RunWith(AndroidJUnit4::class)
 class HomeScreenAppBarTest {
 
     @get:Rule
-    val composeRule = createAndroidComposeRule<ComponentActivity>()
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun rendersBackgroundAndLists() = runBlocking {
-        val alarms = listOf(
-            SunAlarm(
-                type = SunEventType.SUNRISE,
-                offsetMinutes = 30,
-                label = "Test alarm",
-                enabled = true
+    fun rendersAppBarBackgroundAndAlarmRows() {
+        val sunrise = ZonedDateTime.of(2024, 6, 1, 6, 0, 0, 0, ZoneId.of("UTC"))
+        val sunset = ZonedDateTime.of(2024, 6, 1, 20, 0, 0, 0, ZoneId.of("UTC"))
+        val state = HomeViewModel.State(
+            isLoading = false,
+            sunriseTime = sunrise,
+            sunsetTime = sunset,
+            sunriseTimeText = "06:00",
+            sunsetTimeText = "20:00",
+            sunriseAlarms = listOf(
+                SunAlarm(
+                    id = "sunrise-1",
+                    type = SunEventType.SUNRISE,
+                    offsetMinutes = 30,
+                    label = "Morning walk",
+                    enabled = true
+                )
             ),
-            SunAlarm(
-                type = SunEventType.SUNSET,
-                offsetMinutes = -15,
-                label = "Evening",
-                enabled = true
-            )
-        )
-        val settingsRepo = object : SettingsRepository {
-            override suspend fun load(): UserSettings = UserSettings(
-                locationMode = LocationMode.FIXED,
-                fixedLocation = Coordinate(0.0, 0.0),
-                sunriseConfig = SunAlarmConfig(true, SunEventType.SUNRISE, 0),
-                sunsetConfig = SunAlarmConfig(true, SunEventType.SUNSET, 0),
-                timeFormat24h = true,
-                onboardingComplete = true,
-                alarms = alarms
-            )
-
-            override suspend fun save(settings: UserSettings) = Unit
-            override suspend fun loadAlarms(): List<SunAlarm> = alarms
-            override suspend fun saveAlarms(alarms: List<SunAlarm>) = Unit
-        }
-        val viewModel = HomeViewModel(
-            locationService = object : LocationProvider {
-                override suspend fun currentCoordinate(): Coordinate? = Coordinate(0.0, 0.0)
-            },
-            settingsStore = settingsRepo,
-            scheduleService = object : SunScheduler {
-                override suspend fun schedule(coordinate: Coordinate, zoneId: ZoneId) = Unit
-            },
-            sunTimesCalculator = SunTimesCalculator()
+            sunsetAlarms = listOf(
+                SunAlarm(
+                    id = "sunset-1",
+                    type = SunEventType.SUNSET,
+                    offsetMinutes = -15,
+                    label = "Evening wind down",
+                    enabled = true
+                )
+            ),
+            error = null
         )
 
-        composeRule.setContent {
+        composeTestRule.setContent {
             SuntimeAlertsTheme {
-                HomeScreen(viewModel)
+                HomeScreenContent(
+                    state = state,
+                    onAddAlarm = { _, _, _, _ -> },
+                    onUpdateAlarm = {},
+                    onToggleAlarmEnabled = { _, _ -> },
+                    onDeleteAlarm = {},
+                    onDuplicateAlarm = {},
+                    onRestoreAlarm = {}
+                )
             }
         }
 
-        composeRule.waitForIdle()
-
-        composeRule.onNodeWithTag("sun_appbar_background").assertIsDisplayed()
-        composeRule.onNodeWithText("Sunrise").assertExists()
-        composeRule.onNodeWithText("Sunset").assertExists()
-        composeRule.onNodeWithText("+30m").assertExists()
+        composeTestRule.onNodeWithTag("sun_appbar_background").assertExists()
+        composeTestRule.onNodeWithText("Sunrise").assertExists()
+        composeTestRule.onNodeWithText("Sunset").assertExists()
+        composeTestRule.onNodeWithText(formatOffset(30)).assertExists()
+        composeTestRule.onNodeWithText(formatOffset(-15)).assertExists()
     }
 }

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreen.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreen.kt
@@ -77,6 +77,28 @@ import kotlin.random.Random
 @Composable
 fun HomeScreen(viewModel: HomeViewModel) {
     val state by viewModel.state.collectAsState()
+    HomeScreenContent(
+        state = state,
+        onAddAlarm = viewModel::addAlarm,
+        onUpdateAlarm = viewModel::updateAlarm,
+        onToggleAlarmEnabled = viewModel::toggleAlarmEnabled,
+        onDeleteAlarm = viewModel::deleteAlarm,
+        onDuplicateAlarm = viewModel::duplicateAlarm,
+        onRestoreAlarm = viewModel::restoreAlarm
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeScreenContent(
+    state: HomeViewModel.State,
+    onAddAlarm: (SunEventType, Int, String, Boolean) -> Unit,
+    onUpdateAlarm: (SunAlarm) -> Unit,
+    onToggleAlarmEnabled: (String, Boolean) -> Unit,
+    onDeleteAlarm: (String) -> Unit,
+    onDuplicateAlarm: (String) -> Unit,
+    onRestoreAlarm: (SunAlarm) -> Unit
+) {
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
     var editingAlarm by remember { mutableStateOf<SunAlarm?>(null) }
@@ -126,42 +148,42 @@ fun HomeScreen(viewModel: HomeViewModel) {
                     timeText = state.sunriseTimeText,
                     alarms = state.sunriseAlarms,
                     onAdd = { openSheet(null, SunEventType.SUNRISE) },
-                    onToggle = { alarm, enabled -> viewModel.toggleAlarmEnabled(alarm.id, enabled) },
+                    onToggle = { alarm, enabled -> onToggleAlarmEnabled(alarm.id, enabled) },
                     onEdit = { openSheet(it, it.type) },
                     onDelete = { alarm ->
-                        viewModel.deleteAlarm(alarm.id)
+                        onDeleteAlarm(alarm.id)
                         scope.launch {
                             val result = snackbarHostState.showSnackbar(
                                 message = "Sunrise alarm deleted",
                                 actionLabel = "Undo"
                             )
                             if (result == SnackbarResult.ActionPerformed) {
-                                viewModel.restoreAlarm(alarm)
+                                onRestoreAlarm(alarm)
                             }
                         }
                     },
-                    onDuplicate = { viewModel.duplicateAlarm(it.id) }
+                    onDuplicate = { onDuplicateAlarm(it.id) }
                 )
                 AlarmSection(
                     title = "Sunset",
                     timeText = state.sunsetTimeText,
                     alarms = state.sunsetAlarms,
                     onAdd = { openSheet(null, SunEventType.SUNSET) },
-                    onToggle = { alarm, enabled -> viewModel.toggleAlarmEnabled(alarm.id, enabled) },
+                    onToggle = { alarm, enabled -> onToggleAlarmEnabled(alarm.id, enabled) },
                     onEdit = { openSheet(it, it.type) },
                     onDelete = { alarm ->
-                        viewModel.deleteAlarm(alarm.id)
+                        onDeleteAlarm(alarm.id)
                         scope.launch {
                             val result = snackbarHostState.showSnackbar(
                                 message = "Sunset alarm deleted",
                                 actionLabel = "Undo"
                             )
                             if (result == SnackbarResult.ActionPerformed) {
-                                viewModel.restoreAlarm(alarm)
+                                onRestoreAlarm(alarm)
                             }
                         }
                     },
-                    onDuplicate = { viewModel.duplicateAlarm(it.id) }
+                    onDuplicate = { onDuplicateAlarm(it.id) }
                 )
             }
         }
@@ -174,9 +196,9 @@ fun HomeScreen(viewModel: HomeViewModel) {
             onDismiss = { showSheet = false },
             onSave = { alarm ->
                 if (editingAlarm == null) {
-                    viewModel.addAlarm(alarm.type, alarm.offsetMinutes, alarm.label, alarm.enabled)
+                    onAddAlarm(alarm.type, alarm.offsetMinutes, alarm.label, alarm.enabled)
                 } else {
-                    viewModel.updateAlarm(alarm)
+                    onUpdateAlarm(alarm)
                 }
                 showSheet = false
             }


### PR DESCRIPTION
- Exposed a reusable `HomeScreenContent` composable that keeps the alarms UI wiring intact while delegating alarm actions via callbacks for easier testing.
- Simplified the Home screen Compose UI test to render a fixed alarm state through `HomeScreenContent` and assert the sun app bar background and alarm offset rows. 
- Simplified the Home screen Compose UI test to render a fixed alarm state through `HomeScreenContent` and assert the sun app bar background and alarm offset rows.