### PR TITLE
Implement Add/Edit modal bottom sheet

### DIFF
--- a/android/app/src/androidTest/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreenAppBarTest.kt
+++ b/android/app/src/androidTest/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreenAppBarTest.kt
@@ -2,8 +2,11 @@ package com.bfalls.suntimealerts.alarm.presentation.ui
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.bfalls.suntimealerts.alarm.domain.model.SunAlarm
 import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
@@ -72,5 +75,46 @@ class HomeScreenAppBarTest {
         composeTestRule.onNodeWithText("Sunset").assertExists()
         composeTestRule.onNodeWithText(formatOffset(30)).assertExists()
         composeTestRule.onNodeWithText(formatOffset(-15)).assertExists()
+    }
+
+    @Test
+    fun addSheetShowsOffsetControlsAndCanCancel() {
+        val sunrise = ZonedDateTime.of(2024, 6, 1, 6, 0, 0, 0, ZoneId.of("UTC"))
+        val sunset = ZonedDateTime.of(2024, 6, 1, 20, 0, 0, 0, ZoneId.of("UTC"))
+        val state = HomeViewModel.State(
+            isLoading = false,
+            sunriseTime = sunrise,
+            sunsetTime = sunset,
+            sunriseTimeText = "06:00",
+            sunsetTimeText = "20:00",
+            sunriseAlarms = emptyList(),
+            sunsetAlarms = emptyList(),
+            error = null
+        )
+
+        composeTestRule.setContent {
+            SuntimeAlertsTheme {
+                HomeScreenContent(
+                    state = state,
+                    onAddAlarm = { _, _, _, _ -> },
+                    onUpdateAlarm = {},
+                    onToggleAlarmEnabled = { _, _ -> },
+                    onDeleteAlarm = {},
+                    onDuplicateAlarm = {},
+                    onRestoreAlarm = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Add alarm").performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("Before").assertExists()
+        composeTestRule.onNodeWithText("After").assertExists()
+        composeTestRule.onNodeWithText("Hours").assertExists()
+        composeTestRule.onNodeWithText("Minutes").assertExists()
+        composeTestRule.onNodeWithText("Cancel").performClick()
+
+        composeTestRule.onNodeWithText("Label").assertDoesNotExist()
     }
 }

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreen.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreen.kt
@@ -396,26 +396,37 @@ private fun AlarmEditorSheet(
                 Text("Enabled")
                 Switch(checked = enabled, onCheckedChange = { enabled = it })
             }
-            Button(
-                onClick = {
-                    val totalMinutes = hours * 60 + minutes
-                    val offset = if (isAfter) totalMinutes else -totalMinutes
-                    val updated = initialAlarm?.copy(
-                        type = type,
-                        offsetMinutes = offset,
-                        label = label,
-                        enabled = enabled
-                    ) ?: SunAlarm(
-                        type = type,
-                        offsetMinutes = offset,
-                        label = label,
-                        enabled = enabled
-                    )
-                    onSave(updated)
-                },
-                modifier = Modifier.fillMaxWidth()
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                Text("Save")
+                TextButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text("Cancel")
+                }
+                Button(
+                    onClick = {
+                        val totalMinutes = hours * 60 + minutes
+                        val offset = if (isAfter) totalMinutes else -totalMinutes
+                        val updated = initialAlarm?.copy(
+                            type = type,
+                            offsetMinutes = offset,
+                            label = label,
+                            enabled = enabled
+                        ) ?: SunAlarm(
+                            type = type,
+                            offsetMinutes = offset,
+                            label = label,
+                            enabled = enabled
+                        )
+                        onSave(updated)
+                    },
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text("Save")
+                }
             }
             Spacer(modifier = Modifier.height(8.dp))
         }


### PR DESCRIPTION
- Added a cancel action and balanced action row to the alarm editor bottom sheet so users can dismiss edits without saving.
- Added a Compose instrumentation test that opens the add sheet, verifies the offset controls, and confirms it can be cancelled.