### PR TITLE
Fix exact-alarm crash on Android 12+ (#21)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
     <application
         android:allowBackup="true"

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/services/NotificationScheduler.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/services/NotificationScheduler.kt
@@ -8,6 +8,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
@@ -60,7 +61,21 @@ class NotificationScheduler(private val context: Context) : AlarmScheduler {
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
-        alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pending)
+        val canScheduleExact = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            alarmManager.canScheduleExactAlarms()
+        } else {
+            true
+        }
+
+        if (canScheduleExact) {
+            alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pending)
+        } else {
+            Log.w(
+                "NotificationScheduler",
+                "Exact alarms not permitted; scheduling inexact alarm instead."
+            )
+            alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pending)
+        }
         rememberRequestCode(requestCode)
     }
 


### PR DESCRIPTION
Fixes #21
- Added the `SCHEDULE_EXACT_ALARM` permission to the Android manifest so the app can request exact alarms on newer Android versions.
- Guarded exact alarm scheduling by checking `canScheduleExactAlarms()` on Android 12+, falling back to `setAndAllowWhileIdle` with a warning log when exact alarms are not permitted, while keeping exact scheduling on older APIs.