### PR TITLE
Fix uneven Sunrise/Sunset list sections (#25)

### DIFF
--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreen.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreen.kt
@@ -9,13 +9,12 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -28,6 +27,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
@@ -61,7 +61,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -143,54 +142,64 @@ fun HomeScreenContent(
                 Text("Loading…")
             }
         } else {
-            Column(
+            Box(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(padding)
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
+                    .padding(horizontal = 16.dp, vertical = 12.dp)
             ) {
-                AlarmSection(
-                    title = "Sunrise",
-                    timeText = state.sunriseTimeText,
-                    alarms = state.sunriseAlarms,
-                    onAdd = { openSheet(null, SunEventType.SUNRISE) },
-                    onToggle = { alarm, enabled -> onToggleAlarmEnabled(alarm.id, enabled) },
-                    onEdit = { openSheet(it, it.type) },
-                    onDelete = { alarm ->
-                        onDeleteAlarm(alarm.id)
-                        scope.launch {
-                            val result = snackbarHostState.showSnackbar(
-                                message = "Sunrise alarm deleted",
-                                actionLabel = "Undo"
-                            )
-                            if (result == SnackbarResult.ActionPerformed) {
-                                onRestoreAlarm(alarm)
+                Column(modifier = Modifier.fillMaxSize()) {
+                    AlarmSection(
+                        title = "Sunrise",
+                        timeText = state.sunriseTimeText,
+                        alarms = state.sunriseAlarms,
+                        modifier = Modifier.weight(1f),
+                        onAdd = { openSheet(null, SunEventType.SUNRISE) },
+                        onToggle = { alarm, enabled -> onToggleAlarmEnabled(alarm.id, enabled) },
+                        onEdit = { openSheet(it, it.type) },
+                        onDelete = { alarm ->
+                            onDeleteAlarm(alarm.id)
+                            scope.launch {
+                                val result = snackbarHostState.showSnackbar(
+                                    message = "Sunrise alarm deleted",
+                                    actionLabel = "Undo"
+                                )
+                                if (result == SnackbarResult.ActionPerformed) {
+                                    onRestoreAlarm(alarm)
+                                }
                             }
-                        }
-                    },
-                    onDuplicate = { onDuplicateAlarm(it.id) }
-                )
-                AlarmSection(
-                    title = "Sunset",
-                    timeText = state.sunsetTimeText,
-                    alarms = state.sunsetAlarms,
-                    onAdd = { openSheet(null, SunEventType.SUNSET) },
-                    onToggle = { alarm, enabled -> onToggleAlarmEnabled(alarm.id, enabled) },
-                    onEdit = { openSheet(it, it.type) },
-                    onDelete = { alarm ->
-                        onDeleteAlarm(alarm.id)
-                        scope.launch {
-                            val result = snackbarHostState.showSnackbar(
-                                message = "Sunset alarm deleted",
-                                actionLabel = "Undo"
-                            )
-                            if (result == SnackbarResult.ActionPerformed) {
-                                onRestoreAlarm(alarm)
+                        },
+                        onDuplicate = { onDuplicateAlarm(it.id) }
+                    )
+                    AlarmSection(
+                        title = "Sunset",
+                        timeText = state.sunsetTimeText,
+                        alarms = state.sunsetAlarms,
+                        modifier = Modifier.weight(1f),
+                        onAdd = { openSheet(null, SunEventType.SUNSET) },
+                        onToggle = { alarm, enabled -> onToggleAlarmEnabled(alarm.id, enabled) },
+                        onEdit = { openSheet(it, it.type) },
+                        onDelete = { alarm ->
+                            onDeleteAlarm(alarm.id)
+                            scope.launch {
+                                val result = snackbarHostState.showSnackbar(
+                                    message = "Sunset alarm deleted",
+                                    actionLabel = "Undo"
+                                )
+                                if (result == SnackbarResult.ActionPerformed) {
+                                    onRestoreAlarm(alarm)
+                                }
                             }
-                        }
-                    },
-                    onDuplicate = { onDuplicateAlarm(it.id) }
+                        },
+                        onDuplicate = { onDuplicateAlarm(it.id) }
+                    )
+                }
+                HorizontalDivider(
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .fillMaxWidth(),
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
+                    thickness = 1.dp
                 )
             }
         }
@@ -214,20 +223,21 @@ fun HomeScreenContent(
 }
 
 @Composable
-private fun ColumnScope.AlarmSection(
+private fun AlarmSection(
     title: String,
     timeText: String?,
     alarms: List<SunAlarm>,
+    modifier: Modifier = Modifier,
     onAdd: () -> Unit,
     onToggle: (SunAlarm, Boolean) -> Unit,
     onEdit: (SunAlarm) -> Unit,
     onDelete: (SunAlarm) -> Unit,
     onDuplicate: (SunAlarm) -> Unit
 ) {
-    val listHeight = LocalConfiguration.current.screenHeightDp.dp / 2
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
+            .fillMaxHeight()
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -245,7 +255,7 @@ private fun ColumnScope.AlarmSection(
         LazyColumn(
             modifier = Modifier
                 .fillMaxWidth()
-                .heightIn(min = 120.dp, max = listHeight)
+                .weight(1f)
         ) {
             items(alarms, key = { it.id }) { alarm ->
                 AlarmRow(


### PR DESCRIPTION
Fixes #25 
- Evened the two alarm sections to split the available space 50/50 and added a visual separator centered between them, maintained layout height. Updated `AlarmSection` to accept a modifier and use a weighted list so each section fills its
  allotted half cleanly.