### PR TITLE
Align Android SDK/API levels for Play Store

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,14 +6,12 @@ plugins {
 
 android {
     namespace = "com.bfalls.suntimealerts"
-    compileSdk {
-        version = release(36)
-    }
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.bfalls.suntimealerts"
-        minSdk = 24
-        targetSdk = 36
+        minSdk = 26
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreen.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreen.kt
@@ -1,7 +1,9 @@
 package com.bfalls.suntimealerts.alarm.presentation.ui
 
+import android.annotation.SuppressLint
 import android.graphics.Paint
 import android.graphics.drawable.ColorDrawable
+import android.os.Build
 import android.widget.EditText
 import android.widget.NumberPicker
 import androidx.annotation.VisibleForTesting
@@ -825,6 +827,7 @@ private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawStars(
     }
 }
 
+@SuppressLint("SoonBlockedPrivateApi")
 private fun styleNumberPicker(
     numberPicker: NumberPicker,
     textColor: Color,
@@ -837,20 +840,22 @@ private fun styleNumberPicker(
             child.setTextColor(textColorInt)
         }
     }
-    try {
-        val selectorWheelPaintField = NumberPicker::class.java.getDeclaredField("mSelectorWheelPaint")
-        selectorWheelPaintField.isAccessible = true
-        val paint = selectorWheelPaintField.get(numberPicker) as Paint
-        paint.color = textColorInt
-    } catch (_: Exception) {
-        // Best-effort styling for OEM variations.
-    }
-    try {
-        val selectionDividerField = NumberPicker::class.java.getDeclaredField("mSelectionDivider")
-        selectionDividerField.isAccessible = true
-        selectionDividerField.set(numberPicker, ColorDrawable(dividerColor.toArgb()))
-    } catch (_: Exception) {
-        // Ignore if the field is not available.
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+        try {
+            val selectorWheelPaintField = NumberPicker::class.java.getDeclaredField("mSelectorWheelPaint")
+            selectorWheelPaintField.isAccessible = true
+            val paint = selectorWheelPaintField.get(numberPicker) as Paint
+            paint.color = textColorInt
+        } catch (_: Exception) {
+            // Best-effort styling for OEM variations.
+        }
+        try {
+            val selectionDividerField = NumberPicker::class.java.getDeclaredField("mSelectionDivider")
+            selectionDividerField.isAccessible = true
+            selectionDividerField.set(numberPicker, ColorDrawable(dividerColor.toArgb()))
+        } catch (_: Exception) {
+            // Ignore if the field is not available.
+        }
     }
     numberPicker.invalidate()
 }


### PR DESCRIPTION
- Updated the Android app module to use a consistent SDK baseline with compileSdk/targetSdk 35 and minSdk 26 for Play Store readiness.
- Limited number picker reflection-based styling to pre-Android 15 devices and suppressed the soon-blocked private API lint check to keep builds clean while retaining styling on supported versions.