### PR TITLE
(#45) Fix delete snackbar behavior

### DIFF
--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreen.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -171,7 +172,7 @@ fun HomeScreenContent(
     onToggleAlarmEnabled: (String, Boolean) -> Unit,
     onDeleteAlarm: (String) -> Unit,
     onDuplicateAlarm: (SunAlarm) -> Unit,
-    onRestoreAlarm: (SunAlarm) -> Unit
+    onRestoreAlarm: (SunAlarm, Int) -> Unit
 ) {
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -188,14 +189,17 @@ fun HomeScreenContent(
     val readyToRender = !state.isLoading && hasSunTimes
     val typeLabel: (SunAlarm) -> String = { alarm -> if (alarm.type == SunEventType.SUNRISE) "Sunrise" else "Sunset" }
     val handleDelete: (SunAlarm) -> Unit = { alarm ->
+        val deleteIndex = (state.sunriseAlarms + state.sunsetAlarms).indexOfFirst { it.id == alarm.id }
         onDeleteAlarm(alarm.id)
         scope.launch {
+            snackbarHostState.currentSnackbarData?.dismiss()
             val result = snackbarHostState.showSnackbar(
                 message = "${typeLabel(alarm)} alarm deleted",
-                actionLabel = "Undo"
+                actionLabel = "Undo",
+                duration = SnackbarDuration.Short
             )
             if (result == SnackbarResult.ActionPerformed) {
-                onRestoreAlarm(alarm)
+                onRestoreAlarm(alarm, deleteIndex)
             }
         }
     }

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/HomeViewModel.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/HomeViewModel.kt
@@ -123,10 +123,14 @@ class HomeViewModel(
         }
     }
 
-    fun restoreAlarm(alarm: SunAlarm) {
+    fun restoreAlarm(alarm: SunAlarm, index: Int) {
         viewModelScope.launch {
             val existing = _state.value.allAlarms().filterNot { it.id == alarm.id }
-            persistAlarms(existing + alarm)
+            val insertIndex = index.coerceIn(0, existing.size)
+            val updated = existing.toMutableList().apply {
+                add(insertIndex, alarm)
+            }
+            persistAlarms(updated)
         }
     }
 


### PR DESCRIPTION
Fixes #45 

- Ensured delete snackbars dismiss any existing message, use a short duration, and only trigger undo on action selection.
- Captured the deleted alarm’s index and clamped reinsertion on undo so alarms are restored to their original position.