### PR TITLE
(#52) Fix alarm scheduling and canceling logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,18 @@ Suntime Alerts is a dual-native mobile app (iOS + Android) that schedules alarms
 - Daily recomputation and rescheduling reacting to time zone, DST, and location changes.
 - Testable core logic with unit tests for solar calculations and scheduling offsets on both platforms.
 
+## Android: verifying alarm state via ADB
+Use these commands to confirm that the system AlarmManager state matches in-app alarm toggles:
+
+1. Clear app state (optional): `adb shell pm clear com.bfalls.suntimealerts`
+2. Inspect future alarms (should be empty after disabling/deleting all alarms):
+   ```bash
+   PKG=com.bfalls.suntimealerts
+   adb shell dumpsys alarm | grep "$PKG" | grep "OW=" | sed -n 's/.*OW=\([0-9-]* [0-9:]*\).*/\1 &/p' | awk -v now="$(adb shell date '+%Y-%m-%d %H:%M:%S')" '$1 " " $2 > now'
+   ```
+3. Trigger a manual reconcile if needed (debug-only broadcast):
+   ```bash
+   adb shell am broadcast -a com.bfalls.suntimealerts.DEBUG_RECONCILE_ALARMS
+   ```
+
 See [DESIGN.md](DESIGN.md) for detailed flows, algorithms, and extension notes.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:allowBackup="true"
@@ -31,6 +32,16 @@
         <receiver
             android:name=".alarm.services.SunEventReceiver"
             android:exported="false" />
+        <receiver
+            android:name=".alarm.services.AlarmReconcileReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.TIMEZONE_CHANGED" />
+                <action android:name="android.intent.action.TIME_SET" />
+                <action android:name="com.bfalls.suntimealerts.DEBUG_RECONCILE_ALARMS" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/data/SettingsStore.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/data/SettingsStore.kt
@@ -11,6 +11,8 @@ import androidx.datastore.preferences.preferencesDataStore
 import com.bfalls.suntimealerts.alarm.domain.model.ALL_DAYS_MASK
 import com.bfalls.suntimealerts.alarm.domain.model.Coordinate
 import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
+import com.bfalls.suntimealerts.alarm.domain.model.DEFAULT_SUNRISE_ALARM_ID
+import com.bfalls.suntimealerts.alarm.domain.model.DEFAULT_SUNSET_ALARM_ID
 import com.bfalls.suntimealerts.alarm.domain.model.SunAlarm
 import com.bfalls.suntimealerts.alarm.domain.model.SunAlarmConfig
 import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
@@ -20,7 +22,6 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.flow.first
-import java.util.UUID
 
 interface SettingsRepository {
     suspend fun load(): UserSettings
@@ -144,7 +145,7 @@ internal fun migrateLegacyAlarms(
     sunsetEnabled: Boolean
 ): List<SunAlarm> = listOf(
     SunAlarm(
-        id = UUID.randomUUID().toString(),
+        id = DEFAULT_SUNRISE_ALARM_ID,
         type = SunEventType.SUNRISE,
         offsetMinutes = sunriseOffset,
         label = "Sunrise",
@@ -153,7 +154,7 @@ internal fun migrateLegacyAlarms(
         vibrate = true
     ),
     SunAlarm(
-        id = UUID.randomUUID().toString(),
+        id = DEFAULT_SUNSET_ALARM_ID,
         type = SunEventType.SUNSET,
         offsetMinutes = sunsetOffset,
         label = "Sunset",

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/data/SunScheduleService.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/data/SunScheduleService.kt
@@ -1,16 +1,20 @@
 package com.bfalls.suntimealerts.alarm.data
 
 import android.os.Build
+import android.util.Log
 import androidx.annotation.RequiresApi
 import com.bfalls.suntimealerts.alarm.domain.model.Coordinate
+import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
 import com.bfalls.suntimealerts.alarm.domain.service.AlarmOccurrenceCalculator
 import com.bfalls.suntimealerts.alarm.domain.service.SunTimesCalculator
 import com.bfalls.suntimealerts.alarm.services.AlarmScheduler
+import java.time.LocalDate
 import java.time.Clock
 import java.time.ZoneId
 
 interface SunScheduler {
     suspend fun schedule(coordinate: Coordinate, zoneId: ZoneId)
+    suspend fun cancel(alarm: com.bfalls.suntimealerts.alarm.domain.model.SunAlarm, zoneId: ZoneId)
 }
 
 class SunScheduleService(
@@ -18,27 +22,86 @@ class SunScheduleService(
     private val settingsStore: SettingsRepository,
     private val notificationScheduler: AlarmScheduler,
     private val clock: Clock = Clock.systemDefaultZone()
-) : SunScheduler {
+    ) : SunScheduler {
     private val occurrenceCalculator = AlarmOccurrenceCalculator(calculator, clock)
+    private val cancelSweepDays = 14
 
     @RequiresApi(Build.VERSION_CODES.O)
     override suspend fun schedule(coordinate: Coordinate, zoneId: ZoneId) {
         val alarms = settingsStore.loadAlarms()
-        notificationScheduler.cancelAll()
-        alarms.filter { it.enabled }.forEach { alarm ->
-            val occurrence = occurrenceCalculator.nextOccurrence(alarm, coordinate, zoneId) ?: return@forEach
-            notificationScheduler.schedule(
-                alarmId = alarm.id,
-                eventType = alarm.type,
-                triggerAtMillis = occurrence.triggerAtMillis,
-                zoneId = zoneId,
-                label = alarm.label,
-                offsetMinutes = alarm.offsetMinutes,
-                date = occurrence.date,
-                soundUri = alarm.soundUri,
-                vibrate = alarm.vibrate ?: true,
-                coordinate = coordinate
-            )
+        alarms.forEach { alarm ->
+            val occurrence = occurrenceCalculator.nextOccurrence(
+                alarm = alarm,
+                coordinate = coordinate,
+                zoneId = zoneId
+            ) ?: return@forEach
+            if (alarm.enabled) {
+                cancelStaleScheduledOccurrences(alarm, occurrence.date)
+                notificationScheduler.schedule(
+                    alarmId = alarm.id,
+                    eventType = alarm.type,
+                    triggerAtMillis = occurrence.triggerAtMillis,
+                    zoneId = zoneId,
+                    label = alarm.label,
+                    offsetMinutes = alarm.offsetMinutes,
+                    date = occurrence.date,
+                    soundUri = alarm.soundUri,
+                    vibrate = alarm.vibrate ?: true,
+                    coordinate = coordinate
+                )
+            } else {
+                cancelAllScheduledOccurrences(alarm.id, occurrence.date)
+            }
         }
+    }
+
+    private fun cancelStaleScheduledOccurrences(
+        alarm: com.bfalls.suntimealerts.alarm.domain.model.SunAlarm,
+        keepDate: LocalDate
+    ) {
+        // Sweep a small window around the target date to clear stale scheduled occurrences for this alarm.
+        // This handles edits (offset/recurrence) that move the next firing to a different date.
+        val datesToCheck = mutableSetOf(keepDate)
+        (1..cancelSweepDays).forEach { offset ->
+            datesToCheck += keepDate.plusDays(offset.toLong())
+            datesToCheck += keepDate.minusDays(offset.toLong())
+        }
+
+        datesToCheck.forEach { date ->
+            SunEventType.values().forEach { eventType ->
+                val isCurrent = eventType == alarm.type && date == keepDate
+                if (isCurrent) return@forEach
+
+                if (notificationScheduler.hasScheduledOccurrence(alarm.id, eventType, date)) {
+                    notificationScheduler.cancelOccurrence(alarm.id, eventType, date)
+                }
+            }
+        }
+    }
+
+    private fun cancelAllScheduledOccurrences(alarmId: String, centerDate: LocalDate) {
+        val datesToCheck = mutableSetOf(centerDate)
+        (1..cancelSweepDays).forEach { offset ->
+            datesToCheck += centerDate.plusDays(offset.toLong())
+            datesToCheck += centerDate.minusDays(offset.toLong())
+        }
+
+        datesToCheck.forEach { date ->
+            SunEventType.values().forEach { eventType ->
+                if (notificationScheduler.hasScheduledOccurrence(alarmId, eventType, date)) {
+                    notificationScheduler.cancelOccurrence(alarmId, eventType, date)
+                }
+            }
+        }
+    }
+
+    override suspend fun cancel(alarm: com.bfalls.suntimealerts.alarm.domain.model.SunAlarm, zoneId: ZoneId) {
+        val coordinate = settingsStore.load().fixedLocation ?: Coordinate(0.0, 0.0)
+        val occurrence = occurrenceCalculator.nextOccurrence(
+            alarm = alarm,
+            coordinate = coordinate,
+            zoneId = zoneId
+        ) ?: return
+        notificationScheduler.cancelOccurrence(alarm.id, alarm.type, occurrence.date)
     }
 }

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/domain/model/SunAlarm.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/domain/model/SunAlarm.kt
@@ -1,11 +1,13 @@
 package com.bfalls.suntimealerts.alarm.domain.model
 
 import java.time.DayOfWeek
-import java.util.UUID
 import kotlin.math.abs
 
+const val DEFAULT_SUNRISE_ALARM_ID = "sunrise"
+const val DEFAULT_SUNSET_ALARM_ID = "sunset"
+
 data class SunAlarm(
-    val id: String = UUID.randomUUID().toString(),
+    val id: String = java.util.UUID.randomUUID().toString(),
     val type: SunEventType,
     val offsetMinutes: Int,
     val label: String,

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/domain/service/AlarmOccurrenceCalculator.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/domain/service/AlarmOccurrenceCalculator.kt
@@ -21,28 +21,41 @@ class AlarmOccurrenceCalculator(
         alarm: SunAlarm,
         coordinate: Coordinate,
         zoneId: ZoneId
-    ): Occurrence? {
+    ): Occurrence? = upcomingOccurrences(
+        alarm = alarm,
+        coordinate = coordinate,
+        zoneId = zoneId,
+        startDate = LocalDate.now(clock.withZone(zoneId)),
+        days = 7
+    ).firstOrNull()
+
+    fun upcomingOccurrences(
+        alarm: SunAlarm,
+        coordinate: Coordinate,
+        zoneId: ZoneId,
+        startDate: LocalDate,
+        days: Int
+    ): List<Occurrence> {
         val zonedClock = clock.withZone(zoneId)
         val nowMillis = Instant.now(zonedClock).toEpochMilli()
-        val startDate = LocalDate.now(zonedClock)
         val recurrenceMask = alarm.recurrenceDays ?: ALL_DAYS_MASK
 
-        for (daysFromNow in 0..6) {
-            val date = startDate.plusDays(daysFromNow.toLong())
-            if (!recurrenceMask.includesDay(date.dayOfWeek)) continue
+        return buildList {
+            for (daysFromNow in 0 until days) {
+                val date = startDate.plusDays(daysFromNow.toLong())
+                if (!recurrenceMask.includesDay(date.dayOfWeek)) continue
 
-            val sunTimes = calculator.calculateSunTimes(date, coordinate, zoneId)
-            val baseTime = when (alarm.type) {
-                SunEventType.SUNRISE -> sunTimes.sunrise
-                SunEventType.SUNSET -> sunTimes.sunset
-            } ?: continue
+                val sunTimes = calculator.calculateSunTimes(date, coordinate, zoneId)
+                val baseTime = when (alarm.type) {
+                    SunEventType.SUNRISE -> sunTimes.sunrise
+                    SunEventType.SUNSET -> sunTimes.sunset
+                } ?: continue
 
-            val triggerAtMillis = baseTime.toInstant().toEpochMilli() + alarm.offsetMinutes * 60 * 1000L
-            if (triggerAtMillis > nowMillis) {
-                return Occurrence(date, triggerAtMillis)
+                val triggerAtMillis = baseTime.toInstant().toEpochMilli() + alarm.offsetMinutes * 60 * 1000L
+                if (triggerAtMillis > nowMillis) {
+                    add(Occurrence(date, triggerAtMillis))
+                }
             }
         }
-
-        return null
     }
 }

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/OnboardingViewModel.kt
@@ -7,6 +7,8 @@ import androidx.lifecycle.viewModelScope
 import com.bfalls.suntimealerts.alarm.data.LocationProvider
 import com.bfalls.suntimealerts.alarm.data.SettingsRepository
 import com.bfalls.suntimealerts.alarm.domain.model.ALL_DAYS_MASK
+import com.bfalls.suntimealerts.alarm.domain.model.DEFAULT_SUNRISE_ALARM_ID
+import com.bfalls.suntimealerts.alarm.domain.model.DEFAULT_SUNSET_ALARM_ID
 import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
 import com.bfalls.suntimealerts.alarm.domain.model.SunAlarm
 import com.bfalls.suntimealerts.alarm.domain.model.SunAlarmConfig
@@ -222,8 +224,9 @@ class OnboardingViewModel(
             val onboardingState = _state.value
             val updatedAlarms = listOf(
                 SunAlarm(
-                    id = existingAlarmsByType[SunEventType.SUNRISE]?.id ?: existingAlarmsByType.values.firstOrNull { it.type == SunEventType.SUNRISE }?.id
-                    ?: java.util.UUID.randomUUID().toString(),
+                    id = existingAlarmsByType[SunEventType.SUNRISE]?.id
+                        ?: existingAlarmsByType.values.firstOrNull { it.type == SunEventType.SUNRISE }?.id
+                        ?: DEFAULT_SUNRISE_ALARM_ID,
                     type = SunEventType.SUNRISE,
                     offsetMinutes = onboardingState.sunriseOffsetMinutes,
                     label = existingAlarmsByType[SunEventType.SUNRISE]?.label ?: "Sunrise",
@@ -232,8 +235,9 @@ class OnboardingViewModel(
                     vibrate = true
                 ),
                 SunAlarm(
-                    id = existingAlarmsByType[SunEventType.SUNSET]?.id ?: existingAlarmsByType.values.firstOrNull { it.type == SunEventType.SUNSET }?.id
-                    ?: java.util.UUID.randomUUID().toString(),
+                    id = existingAlarmsByType[SunEventType.SUNSET]?.id
+                        ?: existingAlarmsByType.values.firstOrNull { it.type == SunEventType.SUNSET }?.id
+                        ?: DEFAULT_SUNSET_ALARM_ID,
                     type = SunEventType.SUNSET,
                     offsetMinutes = onboardingState.sunsetOffsetMinutes,
                     label = existingAlarmsByType[SunEventType.SUNSET]?.label ?: "Sunset",

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/services/AlarmReconcileReceiver.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/services/AlarmReconcileReceiver.kt
@@ -1,0 +1,27 @@
+package com.bfalls.suntimealerts.alarm.services
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class AlarmReconcileReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        val action = intent?.action
+        val pendingResult = goAsync()
+        CoroutineScope(Dispatchers.Default).launch {
+            try {
+                val reason = action ?: "unknown"
+                Log.i("AlarmReconcileReceiver", "Received $reason; reconciling alarms.")
+                AlarmReconciler(context.applicationContext).reconcile(reason)
+            } catch (t: Throwable) {
+                Log.e("AlarmReconcileReceiver", "Failed to reconcile alarms on $action", t)
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/services/AlarmReconciler.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/services/AlarmReconciler.kt
@@ -1,0 +1,44 @@
+package com.bfalls.suntimealerts.alarm.services
+
+import android.app.Application
+import android.content.Context
+import android.util.Log
+import com.bfalls.suntimealerts.alarm.data.LocationProvider
+import com.bfalls.suntimealerts.alarm.data.LocationService
+import com.bfalls.suntimealerts.alarm.data.SettingsRepository
+import com.bfalls.suntimealerts.alarm.data.SettingsStore
+import com.bfalls.suntimealerts.alarm.data.SunScheduleService
+import com.bfalls.suntimealerts.alarm.domain.model.Coordinate
+import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
+import com.bfalls.suntimealerts.alarm.domain.service.SunTimesCalculator
+import java.time.ZoneId
+
+class AlarmReconciler(
+    private val context: Context,
+    private val settingsStore: SettingsRepository = SettingsStore(context),
+    private val locationProvider: LocationProvider = LocationService(context.applicationContext as Application),
+    private val scheduleService: SunScheduleService = SunScheduleService(
+        calculator = SunTimesCalculator(),
+        settingsStore = settingsStore,
+        notificationScheduler = NotificationScheduler(context)
+    ),
+    private val zoneId: ZoneId = ZoneId.systemDefault()
+) {
+
+    suspend fun reconcile(reason: String? = null) {
+        val settings = settingsStore.load()
+        val coordinate = resolveCoordinate(settings) ?: Coordinate(0.0, 0.0)
+        Log.i(
+            "AlarmReconciler",
+            "Reconciling alarms${reason?.let { " ($it)" } ?: ""} using coordinate=$coordinate and zone=$zoneId"
+        )
+        scheduleService.schedule(coordinate, zoneId)
+    }
+
+    private suspend fun resolveCoordinate(settings: com.bfalls.suntimealerts.alarm.domain.model.UserSettings): Coordinate? {
+        return when (settings.locationMode) {
+            LocationMode.FIXED -> settings.fixedLocation
+            LocationMode.DEVICE -> locationProvider.currentCoordinate()
+        }
+    }
+}

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/services/NotificationScheduler.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/services/NotificationScheduler.kt
@@ -8,6 +8,7 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.BroadcastReceiver
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -29,6 +30,8 @@ import com.bfalls.suntimealerts.alarm.domain.model.UserSettings
 import com.bfalls.suntimealerts.alarm.domain.model.formatOffset
 import com.bfalls.suntimealerts.alarm.domain.service.AlarmOccurrenceCalculator
 import com.bfalls.suntimealerts.alarm.domain.service.SunTimesCalculator
+import com.bfalls.suntimealerts.alarm.services.SunEventIntentFactory
+import com.bfalls.suntimealerts.alarm.services.SunEventIntentFactory.ACTION_SUN_EVENT_ALARM
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -52,13 +55,21 @@ interface AlarmScheduler {
         coordinate: Coordinate
     )
 
-    fun cancelAll()
+    fun hasScheduledOccurrence(
+        alarmId: String,
+        eventType: SunEventType,
+        date: LocalDate
+    ): Boolean
+
+    fun cancelOccurrence(
+        alarmId: String,
+        eventType: SunEventType,
+        date: LocalDate
+    )
 }
 
 class NotificationScheduler(private val context: Context) : AlarmScheduler {
     private val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-    private val prefs = context.getSharedPreferences("sun_alarm_requests", Context.MODE_PRIVATE)
-    private val requestCodesKey = "request_codes"
 
     override fun schedule(
         alarmId: String,
@@ -72,29 +83,27 @@ class NotificationScheduler(private val context: Context) : AlarmScheduler {
         vibrate: Boolean,
         coordinate: Coordinate
     ) {
-        val intent = Intent(context, SunEventReceiver::class.java).apply {
-            putExtra("type", eventType.name)
-            putExtra("alarmId", alarmId)
-            putExtra("label", label)
-            putExtra("offsetMinutes", offsetMinutes)
-            putExtra("zoneId", zoneId.id)
-            putExtra("soundUri", soundUri)
-            putExtra("vibrate", vibrate)
-            putExtra("latitude", coordinate.latitude)
-            putExtra("longitude", coordinate.longitude)
-        }
-        val requestCode = requestCode(alarmId, date)
+        val identity = SunEventIntentFactory.computeIdentity(alarmId, date, eventType)
+        val intent = SunEventIntentFactory.buildAlarmIntent(
+            alarmId = alarmId,
+            eventType = eventType,
+            label = label,
+            offsetMinutes = offsetMinutes,
+            date = date,
+            zoneId = zoneId,
+            soundUri = soundUri,
+            vibrate = vibrate,
+            coordinate = coordinate
+        )
         val pending = PendingIntent.getBroadcast(
             context,
-            requestCode,
+            identity.requestCode,
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
-        val scheduledTime = Instant.ofEpochMilli(triggerAtMillis).atZone(zoneId)
         Log.i(
             "NotificationScheduler",
-            "Scheduling ${eventType.name.lowercase()} alarm (id=$alarmId, label=$label, offset=${formatOffset(offsetMinutes)}) " +
-                "for ${scheduledTime.toLocalDate()} ${scheduledTime.toLocalTime()} ${scheduledTime.zone}"
+            "Scheduling ${formatOffset(offsetMinutes)} ${eventType.name.lowercase()} (${SunEventIntentFactory.describe(identity, triggerAtMillis, zoneId)})"
         )
         val canScheduleExact = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             alarmManager.canScheduleExactAlarms()
@@ -111,42 +120,96 @@ class NotificationScheduler(private val context: Context) : AlarmScheduler {
             )
             alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pending)
         }
-        rememberRequestCode(requestCode)
     }
 
-    override fun cancelAll() {
-        val codes = loadRequestCodes()
-        codes.forEach { cancel(it) }
-        prefs.edit().remove(requestCodesKey).apply()
+    override fun cancelOccurrence(
+        alarmId: String,
+        eventType: SunEventType,
+        date: LocalDate
+    ) {
+        cancelForOccurrence(alarmId, eventType, date)
     }
 
-    private fun cancel(requestCode: Int) {
-        val intent = Intent(context, SunEventReceiver::class.java).apply {
-            action = "CANCEL"
-        }
+    override fun hasScheduledOccurrence(
+        alarmId: String,
+        eventType: SunEventType,
+        date: LocalDate
+    ): Boolean {
+        val identity = SunEventIntentFactory.computeIdentity(alarmId, date, eventType)
+        val intent = SunEventIntentFactory.buildIdentityIntent(
+            alarmId = alarmId,
+            eventType = eventType,
+            date = date,
+            attachComponent = true
+        )
         val pending = PendingIntent.getBroadcast(
             context,
-            requestCode,
+            identity.requestCode,
+            intent,
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE
+        )
+        if (pending != null) return true
+
+        val legacyRequestCode = abs((alarmId + date.toString()).hashCode())
+        val legacyPending = PendingIntent.getBroadcast(
+            context,
+            legacyRequestCode,
+            intent,
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE
+        )
+        return legacyPending != null
+    }
+
+    private fun cancelForOccurrence(
+        alarmId: String,
+        eventType: SunEventType,
+        date: LocalDate
+    ) {
+        val identity = SunEventIntentFactory.computeIdentity(alarmId, date, eventType)
+        val intent = SunEventIntentFactory.buildIdentityIntent(
+            alarmId = alarmId,
+            eventType = eventType,
+            date = date,
+            attachComponent = true
+        )
+        val pending = PendingIntent.getBroadcast(
+            context,
+            identity.requestCode,
+            intent,
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE
+        ) ?: PendingIntent.getBroadcast(
+            context,
+            identity.requestCode,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val legacyRequestCode = abs((alarmId + date.toString()).hashCode())
+        val legacyPending = PendingIntent.getBroadcast(
+            context,
+            legacyRequestCode,
+            intent,
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE
+        ) ?: PendingIntent.getBroadcast(
+            context,
+            legacyRequestCode,
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
         alarmManager.cancel(pending)
-    }
-
-    private fun rememberRequestCode(code: Int) {
-        val updated = loadRequestCodes().apply { add(code) }.map { it.toString() }.toSet()
-        prefs.edit().putStringSet(requestCodesKey, updated).apply()
-    }
-
-    private fun loadRequestCodes(): MutableSet<Int> {
-        return prefs.getStringSet(requestCodesKey, emptySet())
-            ?.mapNotNull { it.toIntOrNull() }
-            ?.toMutableSet()
-            ?: mutableSetOf()
-    }
-
-    private fun requestCode(alarmId: String, date: LocalDate): Int {
-        return abs((alarmId + date.toString()).hashCode())
+        alarmManager.cancel(legacyPending)
+        pending.cancel()
+        legacyPending.cancel()
+        val verification = PendingIntent.getBroadcast(
+            context,
+            identity.requestCode,
+            intent,
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE
+        )
+        Log.i(
+            "NotificationScheduler",
+            "Canceled alarm id=${identity.alarmId}, event=${identity.eventType.name.lowercase()}, " +
+                "date=${identity.date}, requestCode=${identity.requestCode}, remainingPendingIntent=${verification != null}"
+        )
     }
 }
 
@@ -210,6 +273,10 @@ class SunEventReceiver : BroadcastReceiver() {
         if (intent.action == actionDismiss) {
             val alarmId = intent.getStringExtra("alarmId") ?: return
             NotificationManagerCompat.from(context).cancel(alarmId.hashCode())
+            return
+        }
+        if (intent.action != ACTION_SUN_EVENT_ALARM) {
+            Log.w("SunEventReceiver", "Ignoring intent with unexpected action: ${intent.action}")
             return
         }
 

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/services/SunEventIntentFactory.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/services/SunEventIntentFactory.kt
@@ -1,0 +1,89 @@
+package com.bfalls.suntimealerts.alarm.services
+
+import android.content.ComponentName
+import android.content.Intent
+import com.bfalls.suntimealerts.alarm.domain.model.Coordinate
+import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
+import java.time.LocalDate
+import java.time.ZoneId
+import kotlin.math.abs
+
+object SunEventIntentFactory {
+    const val ACTION_SUN_EVENT_ALARM = "com.bfalls.suntimealerts.SUN_EVENT_ALARM"
+    const val ACTION_DEBUG_RECONCILE_ALARMS = "com.bfalls.suntimealerts.DEBUG_RECONCILE_ALARMS"
+    private const val RECEIVER_PACKAGE = "com.bfalls.suntimealerts"
+
+    data class Identity(
+        val alarmId: String,
+        val date: LocalDate,
+        val eventType: SunEventType,
+        val requestCode: Int
+    )
+
+    fun computeIdentity(alarmId: String, date: LocalDate, eventType: SunEventType): Identity {
+        return Identity(
+            alarmId = alarmId,
+            date = date,
+            eventType = eventType,
+            requestCode = computeRequestCode(alarmId, date, eventType)
+        )
+    }
+
+    fun computeRequestCode(alarmId: String, date: LocalDate, eventType: SunEventType): Int {
+        val seed = "${alarmId.lowercase()}|${eventType.name}|$date"
+        return abs(seed.hashCode())
+    }
+
+    fun buildIdentityIntent(
+        alarmId: String,
+        eventType: SunEventType,
+        date: LocalDate,
+        action: String = ACTION_SUN_EVENT_ALARM,
+        attachComponent: Boolean = true
+    ): Intent {
+        return Intent(action).apply {
+            if (attachComponent) {
+                component = ComponentName(RECEIVER_PACKAGE, SunEventReceiver::class.java.name)
+            }
+            putExtra("type", eventType.name)
+            putExtra("alarmId", alarmId)
+            putExtra("date", date.toString())
+        }
+    }
+
+    fun buildAlarmIntent(
+        alarmId: String,
+        eventType: SunEventType,
+        label: String,
+        offsetMinutes: Int,
+        date: LocalDate,
+        zoneId: ZoneId,
+        soundUri: String?,
+        vibrate: Boolean,
+        coordinate: Coordinate,
+        attachComponent: Boolean = true
+    ): Intent {
+        return Intent(ACTION_SUN_EVENT_ALARM).apply {
+            if (attachComponent) {
+                component = ComponentName(RECEIVER_PACKAGE, SunEventReceiver::class.java.name)
+            }
+            putExtra("type", eventType.name)
+            putExtra("alarmId", alarmId)
+            putExtra("label", label)
+            putExtra("offsetMinutes", offsetMinutes)
+            putExtra("zoneId", zoneId.id)
+            putExtra("soundUri", soundUri)
+            putExtra("vibrate", vibrate)
+            putExtra("latitude", coordinate.latitude)
+            putExtra("longitude", coordinate.longitude)
+            putExtra("date", date.toString())
+        }
+    }
+
+    fun describe(identity: Identity, triggerAtMillis: Long, zoneId: ZoneId): String {
+        val scheduledTime = java.time.Instant.ofEpochMilli(triggerAtMillis).atZone(zoneId)
+        return "id=${identity.alarmId}, event=${identity.eventType.name.lowercase()}, " +
+            "date=${identity.date}, requestCode=${identity.requestCode}, " +
+            "trigger=${scheduledTime.toLocalDate()} ${scheduledTime.toLocalTime()} ${scheduledTime.zone}"
+    }
+}

--- a/android/app/src/test/java/com/bfalls/suntimealerts/alarm/data/SettingsStoreTest.kt
+++ b/android/app/src/test/java/com/bfalls/suntimealerts/alarm/data/SettingsStoreTest.kt
@@ -1,5 +1,7 @@
 package com.bfalls.suntimealerts.alarm.data
 
+import com.bfalls.suntimealerts.alarm.domain.model.DEFAULT_SUNRISE_ALARM_ID
+import com.bfalls.suntimealerts.alarm.domain.model.DEFAULT_SUNSET_ALARM_ID
 import com.bfalls.suntimealerts.alarm.domain.model.SunAlarm
 import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
 import com.bfalls.suntimealerts.alarm.domain.model.withDefaults
@@ -24,11 +26,13 @@ class SettingsStoreTest {
         val sunset = alarms.first { it.type == SunEventType.SUNSET }
         assertEquals(15, sunrise.offsetMinutes)
         assertTrue(sunrise.enabled)
+        assertEquals(DEFAULT_SUNRISE_ALARM_ID, sunrise.id)
         assertEquals(127, sunrise.recurrenceDays)
         assertTrue(sunrise.vibrate == true)
         assertEquals(null, sunrise.soundUri)
         assertEquals(-30, sunset.offsetMinutes)
         assertFalse(sunset.enabled)
+        assertEquals(DEFAULT_SUNSET_ALARM_ID, sunset.id)
         assertEquals(127, sunset.recurrenceDays)
         assertTrue(sunset.vibrate == true)
         assertEquals(null, sunset.soundUri)

--- a/android/app/src/test/java/com/bfalls/suntimealerts/alarm/data/SunScheduleServiceTest.kt
+++ b/android/app/src/test/java/com/bfalls/suntimealerts/alarm/data/SunScheduleServiceTest.kt
@@ -7,6 +7,7 @@ import com.bfalls.suntimealerts.alarm.domain.model.SunAlarmConfig
 import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
 import com.bfalls.suntimealerts.alarm.domain.model.UserSettings
 import com.bfalls.suntimealerts.alarm.domain.model.toBitMask
+import com.bfalls.suntimealerts.alarm.domain.service.AlarmOccurrenceCalculator
 import com.bfalls.suntimealerts.alarm.domain.service.SunTimesCalculator
 import com.bfalls.suntimealerts.alarm.services.AlarmScheduler
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -44,7 +45,7 @@ class SunScheduleServiceTest {
             override suspend fun loadAlarms(): List<SunAlarm> = alarms
             override suspend fun saveAlarms(alarms: List<SunAlarm>) = Unit
 
-            private val alarms = listOf(
+            val alarms = listOf(
                 SunAlarm(
                     type = SunEventType.SUNRISE,
                     offsetMinutes = 30,
@@ -58,11 +59,12 @@ class SunScheduleServiceTest {
 
         service.schedule(coordinate, zone)
 
-        val today = LocalDate.now(clock)
-        val sunTimes = calculator.calculateSunTimes(today, coordinate, zone)
-        val expectedTrigger = requireNotNull(sunTimes.sunrise).toInstant().toEpochMilli() + 30 * 60 * 1000L
+        assertTrue("Should schedule exactly one upcoming occurrence", notificationScheduler.entries.size == 1)
 
-        assertTrue("Only one occurrence should be scheduled per enabled alarm", notificationScheduler.entries.size == 1)
+        val expectedDate = LocalDate.now(clock)
+        val expectedTrigger = requireNotNull(
+            calculator.calculateSunTimes(expectedDate, coordinate, zone).sunrise
+        ).toInstant().toEpochMilli() + 30 * 60 * 1000L
 
         assertTrue(
             notificationScheduler.entries.any {
@@ -100,11 +102,8 @@ class SunScheduleServiceTest {
         service.schedule(coordinate, zone)
 
         val today = LocalDate.now(clock)
-        val tomorrow = today.plusDays(1)
-        val sunTimesTomorrow = calculator.calculateSunTimes(tomorrow, coordinate, zone)
-        val expectedTomorrowTrigger = requireNotNull(sunTimesTomorrow.sunrise).toInstant().toEpochMilli()
         assertTrue(
-            "Should only schedule a single upcoming occurrence",
+            "Should schedule exactly one upcoming occurrence",
             notificationScheduler.entries.size == 1
         )
         assertFalse(
@@ -115,7 +114,7 @@ class SunScheduleServiceTest {
         )
         assertTrue(
             "Should schedule tomorrow's occurrence",
-            notificationScheduler.entries.any { entry -> entry.triggerAtMillis == expectedTomorrowTrigger }
+            notificationScheduler.entries.single().date == today.plusDays(1)
         )
     }
 
@@ -148,9 +147,8 @@ class SunScheduleServiceTest {
         service.schedule(coordinate, zone)
 
         val today = LocalDate.now(clock)
-        val tomorrow = today.plusDays(1)
         assertTrue(
-            "Should only schedule one pending occurrence for the enabled alarm",
+            "Should only schedule one pending occurrence on the next selected day",
             notificationScheduler.entries.size == 1
         )
         assertFalse(
@@ -161,9 +159,7 @@ class SunScheduleServiceTest {
         )
         assertTrue(
             "Should schedule on the next selected day (tomorrow, Wednesday)",
-            notificationScheduler.entries.any { entry ->
-                Instant.ofEpochMilli(entry.triggerAtMillis).atZone(zone).toLocalDate() == tomorrow
-            }
+            notificationScheduler.entries.single().date == today.plusDays(1)
         )
     }
 
@@ -187,12 +183,23 @@ class SunScheduleServiceTest {
                 )
             )
         }
-        val service = SunScheduleService(calculator, repo, notificationScheduler)
-        val coordinate = Coordinate(0.0, 0.0)
+        val fixedInstant = Instant.parse("2024-01-01T00:00:00Z")
         val zone = ZoneId.of("UTC")
+        val clock = Clock.fixed(fixedInstant, zone)
+        val service = SunScheduleService(calculator, repo, notificationScheduler, clock)
+        val coordinate = Coordinate(0.0, 0.0)
 
         service.schedule(coordinate, zone)
         assertTrue(notificationScheduler.entries.isNotEmpty())
+
+        // Simulate a duplicate pending occurrence on the same date that should be removed.
+        val scheduledDate = notificationScheduler.entries.first().date
+        notificationScheduler.entries += RecordingNotificationScheduler.Entry(
+            alarmId = repo.alarms.first().id,
+            eventType = repo.alarms.first().type,
+            triggerAtMillis = Instant.now(clock).plusSeconds(24 * 3600).toEpochMilli(),
+            date = scheduledDate
+        )
 
         repo.alarms = repo.alarms.map { it.copy(enabled = false) }
         service.schedule(coordinate, zone)
@@ -200,11 +207,58 @@ class SunScheduleServiceTest {
         assertTrue(notificationScheduler.entries.isEmpty())
     }
 
+    @Test
+    fun reschedulesWhenEditMovesNextDate() = runTest {
+        val calculator = SunTimesCalculator()
+        val notificationScheduler = RecordingNotificationScheduler()
+        val repo = object : SettingsRepository {
+            override suspend fun load(): UserSettings = TODO("Not used")
+            override suspend fun save(settings: UserSettings) = Unit
+            override suspend fun loadAlarms(): List<SunAlarm> = alarms
+            override suspend fun saveAlarms(alarms: List<SunAlarm>) = Unit
+
+            var alarms: List<SunAlarm> = listOf(
+                SunAlarm(
+                    type = SunEventType.SUNRISE,
+                    offsetMinutes = 0,
+                    label = "Weekday edit",
+                    enabled = true,
+                    recurrenceDays = setOf(DayOfWeek.MONDAY).toBitMask()
+                )
+            )
+        }
+        val fixedInstant = Instant.parse("2024-01-01T00:00:00Z") // Monday
+        val zone = ZoneId.of("UTC")
+        val clock = Clock.fixed(fixedInstant, zone)
+        val service = SunScheduleService(calculator, repo, notificationScheduler, clock)
+        val coordinate = Coordinate(0.0, 0.0)
+
+        service.schedule(coordinate, zone)
+        assertTrue(notificationScheduler.entries.size == 1)
+        val originalDate = notificationScheduler.entries.single().date
+
+        // Change recurrence to Friday, which should move the next occurrence and cancel the original.
+        repo.alarms = repo.alarms.map {
+            it.copy(recurrenceDays = setOf(DayOfWeek.FRIDAY).toBitMask())
+        }
+        service.schedule(coordinate, zone)
+
+        assertTrue(
+            "Old occurrence should be canceled after edit",
+            notificationScheduler.entries.none { it.date == originalDate }
+        )
+        assertTrue(
+            "New occurrence should be scheduled on the edited recurrence day",
+            notificationScheduler.entries.single().date.dayOfWeek == DayOfWeek.FRIDAY
+        )
+    }
+
     private class RecordingNotificationScheduler : AlarmScheduler {
         data class Entry(
             val alarmId: String,
             val eventType: SunEventType,
-            val triggerAtMillis: Long
+            val triggerAtMillis: Long,
+            val date: LocalDate
         )
 
         val entries = mutableListOf<Entry>()
@@ -221,11 +275,23 @@ class SunScheduleServiceTest {
             vibrate: Boolean,
             coordinate: Coordinate
         ) {
-            entries += Entry(alarmId, eventType, triggerAtMillis)
+            entries += Entry(alarmId, eventType, triggerAtMillis, date)
         }
 
-        override fun cancelAll() {
-            entries.clear()
+        override fun hasScheduledOccurrence(alarmId: String, eventType: SunEventType, date: LocalDate): Boolean {
+            return entries.any { entry ->
+                entry.alarmId == alarmId &&
+                    entry.eventType == eventType &&
+                    entry.date == date
+            }
+        }
+
+        override fun cancelOccurrence(alarmId: String, eventType: SunEventType, date: LocalDate) {
+            entries.removeAll { entry ->
+                entry.alarmId == alarmId &&
+                    entry.eventType == eventType &&
+                    entry.date == date
+            }
         }
     }
 }

--- a/android/app/src/test/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/HomeViewModelTest.kt
+++ b/android/app/src/test/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/HomeViewModelTest.kt
@@ -91,5 +91,9 @@ class HomeViewModelTest {
         override suspend fun schedule(coordinate: Coordinate, zoneId: ZoneId) {
             receivedCoordinates += coordinate
         }
+
+        override suspend fun cancel(alarm: SunAlarm, zoneId: ZoneId) {
+            // no-op for tests
+        }
     }
 }

--- a/android/app/src/test/java/com/bfalls/suntimealerts/alarm/services/SunEventIntentFactoryTest.kt
+++ b/android/app/src/test/java/com/bfalls/suntimealerts/alarm/services/SunEventIntentFactoryTest.kt
@@ -1,0 +1,39 @@
+package com.bfalls.suntimealerts.alarm.services
+
+import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import java.time.LocalDate
+
+class SunEventIntentFactoryTest {
+
+    private val sampleDate = LocalDate.of(2024, 1, 1)
+
+    @Test
+    fun `request codes are deterministic for the same inputs`() {
+        val first = SunEventIntentFactory.computeRequestCode("alarm-1", sampleDate, SunEventType.SUNRISE)
+        val second = SunEventIntentFactory.computeRequestCode("alarm-1", sampleDate, SunEventType.SUNRISE)
+
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun `request codes vary across inputs`() {
+        val base = SunEventIntentFactory.computeRequestCode("alarm-1", sampleDate, SunEventType.SUNRISE)
+        val differentAlarm = SunEventIntentFactory.computeRequestCode("alarm-2", sampleDate, SunEventType.SUNRISE)
+        val differentDate = SunEventIntentFactory.computeRequestCode("alarm-1", sampleDate.plusDays(1), SunEventType.SUNRISE)
+        val differentType = SunEventIntentFactory.computeRequestCode("alarm-1", sampleDate, SunEventType.SUNSET)
+
+        assertNotEquals(base, differentAlarm)
+        assertNotEquals(base, differentDate)
+        assertNotEquals(base, differentType)
+    }
+
+    @Test
+    fun `action and receiver metadata are stable`() {
+        assertEquals(SunEventIntentFactory.ACTION_SUN_EVENT_ALARM, "com.bfalls.suntimealerts.SUN_EVENT_ALARM")
+        assertEquals(SunEventIntentFactory.ACTION_DEBUG_RECONCILE_ALARMS, "com.bfalls.suntimealerts.DEBUG_RECONCILE_ALARMS")
+        assertEquals("com.bfalls.suntimealerts.alarm.services.SunEventReceiver", SunEventReceiver::class.java.name)
+    }
+}


### PR DESCRIPTION
Fixes #52 

- Cancel stale scheduled occurrences for an alarm across both sunrise and sunset identities when rescheduling the next fire date, preventing duplicates after edits.
- Clear any scheduled occurrences for disabled alarms across nearby dates while keeping scheduling focused on the newly computed occurrence.
