### PR TITLE
(#54) Remove global enable alerts setting

### DIFF
--- a/android/app/src/main/java/com/bfalls/suntimealerts/MainActivity.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/MainActivity.kt
@@ -287,14 +287,21 @@ class MainActivity : ComponentActivity() {
             }
 
             LaunchedEffect(
+                onboardingState.sunriseEnabled,
+                onboardingState.sunsetEnabled
+            ) {
+                hasEnabledAlarms = onboardingState.sunriseEnabled || onboardingState.sunsetEnabled
+            }
+
+            LaunchedEffect(
                 onboardingState.isLoaded,
                 onboardingState.onboardingComplete,
-                onboardingState.notificationsEnabled
+                hasEnabledAlarms
             ) {
                 if (
                     onboardingState.isLoaded &&
                     onboardingState.onboardingComplete &&
-                    onboardingState.notificationsEnabled &&
+                    hasEnabledAlarms &&
                     Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
                     !hasNotificationPermission(context) &&
                     !notificationPermissionRequested
@@ -430,20 +437,30 @@ class MainActivity : ComponentActivity() {
                                 }
                                 startActivity(intent)
                             },
-                            onNotificationsChanged = { enabled ->
-                                onboardingViewModel.updateNotifications(enabled)
-                                hasEnabledAlarms = enabled
+                            onSunriseEnabledChanged = { enabled ->
+                                onboardingViewModel.updateSunriseEnabled(enabled)
+                                hasEnabledAlarms = enabled || onboardingState.sunsetEnabled
                                 if (
-                                    enabled &&
+                                    hasEnabledAlarms &&
                                     Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
                                     !hasNotificationPermission(context)
                                 ) {
                                     notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                                 }
-                                requestExactAlarmPermission("notifications-toggle")
+                                requestExactAlarmPermission("sunrise-toggle")
                             },
-                            onSunriseEnabledChanged = onboardingViewModel::updateSunriseEnabled,
-                            onSunsetEnabledChanged = onboardingViewModel::updateSunsetEnabled,
+                            onSunsetEnabledChanged = { enabled ->
+                                onboardingViewModel.updateSunsetEnabled(enabled)
+                                hasEnabledAlarms = onboardingState.sunriseEnabled || enabled
+                                if (
+                                    hasEnabledAlarms &&
+                                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                                    !hasNotificationPermission(context)
+                                ) {
+                                    notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                                }
+                                requestExactAlarmPermission("sunset-toggle")
+                            },
                             onSunriseOffsetChanged = onboardingViewModel::updateSunriseOffset,
                             onSunsetOffsetChanged = onboardingViewModel::updateSunsetOffset,
                             onCityQueryChanged = onboardingViewModel::updateCityQuery,

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/OnboardingScreen.kt
@@ -54,7 +54,6 @@ import com.bfalls.suntimealerts.cities.data.City
 fun OnboardingScreen(
     state: OnboardingState,
     onLocationModeChanged: (LocationMode) -> Unit,
-    onNotificationsChanged: (Boolean) -> Unit,
     onSunriseEnabledChanged: (Boolean) -> Unit,
     onSunsetEnabledChanged: (Boolean) -> Unit,
     onSunriseOffsetChanged: (Int) -> Unit,
@@ -108,7 +107,6 @@ fun OnboardingScreen(
                     text = when (state.step) {
                         OnboardingStep.WELCOME -> "Welcome"
                         OnboardingStep.LOCATION -> "Choose location"
-                        OnboardingStep.NOTIFICATIONS -> "Notifications"
                         OnboardingStep.ALARMS -> "Initial alarms"
                         OnboardingStep.SUMMARY -> "Summary"
                     },
@@ -124,7 +122,6 @@ fun OnboardingScreen(
                         onCityQueryChanged,
                         onCitySelected
                     )
-                    OnboardingStep.NOTIFICATIONS -> NotificationStep(state.notificationsEnabled, onNotificationsChanged)
                     OnboardingStep.ALARMS -> AlarmStep(state, onSunriseEnabledChanged, onSunsetEnabledChanged, onSunriseOffsetChanged, onSunsetOffsetChanged)
                     OnboardingStep.SUMMARY -> SummaryStep(state)
                 }
@@ -278,17 +275,6 @@ private fun LocationStep(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun NotificationStep(enabled: Boolean, onChanged: (Boolean) -> Unit) {
-    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text("Enable alerts")
-            Text("Turn on notifications to receive sunrise and sunset reminders.")
-        }
-        Switch(checked = enabled, onCheckedChange = onChanged)
     }
 }
 

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/OnboardingViewModel.kt
@@ -33,14 +33,13 @@ data class OnboardingState(
     val cityQuery: String = "",
     val cityResults: List<City> = emptyList(),
     val selectedCity: City? = null,
-    val notificationsEnabled: Boolean = true,
     val sunriseEnabled: Boolean = true,
     val sunriseOffsetMinutes: Int = 0,
     val sunsetEnabled: Boolean = false,
     val sunsetOffsetMinutes: Int = 0
 )
 
-enum class OnboardingStep { WELCOME, LOCATION, NOTIFICATIONS, ALARMS, SUMMARY }
+enum class OnboardingStep { WELCOME, LOCATION, ALARMS, SUMMARY }
 
 enum class PermissionRequestOrigin { AUTOMATIC, USER }
 
@@ -69,7 +68,6 @@ class OnboardingViewModel(
             locationMode = settings.locationMode,
             fixedLatitude = settings.fixedLocation?.latitude?.toString() ?: "",
             fixedLongitude = settings.fixedLocation?.longitude?.toString() ?: "",
-            notificationsEnabled = sunriseEnabled || sunsetEnabled,
             sunriseEnabled = sunriseEnabled,
             sunriseOffsetMinutes = settings.sunriseConfig.offsetMinutes,
             sunsetEnabled = sunsetEnabled,
@@ -177,16 +175,6 @@ class OnboardingViewModel(
         )
     }
 
-    fun updateNotifications(enabled: Boolean) {
-        val updatedSunriseEnabled = if (enabled) _state.value.sunriseEnabled else false
-        val updatedSunsetEnabled = if (enabled) _state.value.sunsetEnabled else false
-        _state.value = _state.value.copy(
-            notificationsEnabled = enabled,
-            sunriseEnabled = updatedSunriseEnabled,
-            sunsetEnabled = updatedSunsetEnabled
-        )
-    }
-
     fun updateSunriseEnabled(enabled: Boolean) {
         _state.value = _state.value.copy(sunriseEnabled = enabled)
     }
@@ -230,7 +218,7 @@ class OnboardingViewModel(
                     type = SunEventType.SUNRISE,
                     offsetMinutes = onboardingState.sunriseOffsetMinutes,
                     label = existingAlarmsByType[SunEventType.SUNRISE]?.label ?: "Sunrise",
-                    enabled = onboardingState.notificationsEnabled && onboardingState.sunriseEnabled,
+                    enabled = onboardingState.sunriseEnabled,
                     recurrenceDays = ALL_DAYS_MASK,
                     vibrate = true
                 ),
@@ -241,7 +229,7 @@ class OnboardingViewModel(
                     type = SunEventType.SUNSET,
                     offsetMinutes = onboardingState.sunsetOffsetMinutes,
                     label = existingAlarmsByType[SunEventType.SUNSET]?.label ?: "Sunset",
-                    enabled = onboardingState.notificationsEnabled && onboardingState.sunsetEnabled,
+                    enabled = onboardingState.sunsetEnabled,
                     recurrenceDays = ALL_DAYS_MASK,
                     vibrate = true
                 )
@@ -249,12 +237,12 @@ class OnboardingViewModel(
             settings = settings.copy(
                 locationMode = if (_state.value.locationMode == LocationMode.FIXED) LocationMode.FIXED else LocationMode.DEVICE,
                 sunriseConfig = SunAlarmConfig(
-                    enabled = onboardingState.notificationsEnabled && onboardingState.sunriseEnabled,
+                    enabled = onboardingState.sunriseEnabled,
                     eventType = SunEventType.SUNRISE,
                     offsetMinutes = onboardingState.sunriseOffsetMinutes
                 ),
                 sunsetConfig = SunAlarmConfig(
-                    enabled = onboardingState.notificationsEnabled && onboardingState.sunsetEnabled,
+                    enabled = onboardingState.sunsetEnabled,
                     eventType = SunEventType.SUNSET,
                     offsetMinutes = onboardingState.sunsetOffsetMinutes
                 ),


### PR DESCRIPTION
Fixes #54 

- Removed the notifications onboarding step and its callback so the flow moves directly from location selection to alarm configuration.
- Simplified onboarding state to rely solely on per-alarm enablement when loading and saving settings.
- Updated Android permission prompts to trigger from per-alarm toggles instead of a global notification switch.
- Doing this step by step, more onboarding steps to be removed.