### PR TITLE
(#59) Add settings screen and functionality

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
+    implementation("androidx.appcompat:appcompat:1.7.0")
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.graphics)

--- a/android/app/src/main/java/com/bfalls/suntimealerts/MainActivity.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/MainActivity.kt
@@ -13,7 +13,9 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -44,6 +46,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.bfalls.suntimealerts.alarm.data.LocationService
 import com.bfalls.suntimealerts.alarm.data.SettingsStore
 import com.bfalls.suntimealerts.alarm.data.SunScheduleService
+import com.bfalls.suntimealerts.alarm.domain.model.AppThemeMode
 import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
 import com.bfalls.suntimealerts.alarm.domain.service.SunTimesCalculator
 import com.bfalls.suntimealerts.alarm.presentation.ui.HomeScreen
@@ -60,23 +63,26 @@ import com.bfalls.suntimealerts.alarm.services.NotificationScheduler
 import com.bfalls.suntimealerts.cities.data.CityRepository
 import com.bfalls.suntimealerts.cities.presentation.CityImportViewModel
 import com.bfalls.suntimealerts.cities.presentation.CityImportViewModelFactory
-import com.bfalls.suntimealerts.ui.theme.SplashBackground
 import com.bfalls.suntimealerts.ui.theme.SuntimeAlertsTheme
-import com.bfalls.suntimealerts.ui.theme.TextPrimary
-import com.bfalls.suntimealerts.ui.theme.TextSecondary
 import com.bfalls.suntimealerts.utils.ExactAlarmPermissionTracker
 import com.bfalls.suntimealerts.utils.hasLocationPermission
 import com.bfalls.suntimealerts.utils.hasNotificationPermission
+import kotlinx.coroutines.runBlocking
 
 
 class MainActivity : ComponentActivity() {
+    private val settingsStore: SettingsStore by lazy { SettingsStore(applicationContext) }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)
+        runBlocking {
+            applyAppThemeMode(settingsStore.load().appThemeMode)
+        }
         enableEdgeToEdge()
         setContent {
             val context = LocalContext.current
-            val settingsStore = remember { SettingsStore(applicationContext) }
+            val settingsStore = remember { this@MainActivity.settingsStore }
             val locationService = remember { LocationService(application) }
             val notificationScheduler = remember { NotificationScheduler(applicationContext) }
             val sunTimesCalculator = remember { SunTimesCalculator() }
@@ -89,6 +95,7 @@ class MainActivity : ComponentActivity() {
             val onboardingViewModel: OnboardingViewModel = viewModel(
                 factory = OnboardingViewModelFactory(settingsStore, cityRepository, locationService)
             )
+            val settingsState by settingsViewModel.state.collectAsState()
             val onboardingState by onboardingViewModel.state.collectAsState()
             val cityImportViewModel: CityImportViewModel = viewModel(
                 factory = CityImportViewModelFactory(cityRepository)
@@ -281,7 +288,18 @@ class MainActivity : ComponentActivity() {
                 }
             }
 
-            SuntimeAlertsTheme {
+            val appThemeMode = settingsState.appThemeMode
+            val darkTheme = when (appThemeMode) {
+                AppThemeMode.SYSTEM -> isSystemInDarkTheme()
+                AppThemeMode.LIGHT -> false
+                AppThemeMode.DARK -> true
+            }
+
+            LaunchedEffect(appThemeMode) {
+                applyAppThemeMode(appThemeMode)
+            }
+
+            SuntimeAlertsTheme(darkTheme = darkTheme) {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
@@ -290,11 +308,14 @@ class MainActivity : ComponentActivity() {
                         cityImportState.isImporting -> Box(
                             modifier = Modifier
                                 .fillMaxSize()
-                                .background(SplashBackground),
+                                .background(MaterialTheme.colorScheme.background),
                             contentAlignment = Alignment.Center
                         ) {
                             Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                Text(text = "Preparing Suntime Alerts...", color = TextPrimary)
+                                Text(
+                                    text = "Preparing Suntime Alerts...",
+                                    color = MaterialTheme.colorScheme.onBackground
+                                )
                                 Spacer(modifier = Modifier.height(16.dp))
                                 CircularProgressIndicator(
                                     progress = { cityImportState.progress }
@@ -303,7 +324,7 @@ class MainActivity : ComponentActivity() {
                                     Spacer(modifier = Modifier.height(8.dp))
                                     Text(
                                         text = "${cityImportState.current} / ${cityImportState.total}",
-                                        color = TextSecondary
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
                                     )
                                 }
                             }
@@ -412,5 +433,14 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+
+    private fun applyAppThemeMode(mode: AppThemeMode) {
+        val nightMode = when (mode) {
+            AppThemeMode.SYSTEM -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+            AppThemeMode.LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
+            AppThemeMode.DARK -> AppCompatDelegate.MODE_NIGHT_YES
+        }
+        AppCompatDelegate.setDefaultNightMode(nightMode)
     }
 }

--- a/android/app/src/main/java/com/bfalls/suntimealerts/MainActivity.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/MainActivity.kt
@@ -48,11 +48,14 @@ import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
 import com.bfalls.suntimealerts.alarm.domain.service.SunTimesCalculator
 import com.bfalls.suntimealerts.alarm.presentation.ui.HomeScreen
 import com.bfalls.suntimealerts.alarm.presentation.ui.OnboardingScreen
+import com.bfalls.suntimealerts.alarm.presentation.ui.SettingsScreen
 import com.bfalls.suntimealerts.alarm.presentation.viewmodel.HomeViewModel
 import com.bfalls.suntimealerts.alarm.presentation.viewmodel.OnboardingStep
 import com.bfalls.suntimealerts.alarm.presentation.viewmodel.OnboardingViewModel
 import com.bfalls.suntimealerts.alarm.presentation.viewmodel.OnboardingViewModelFactory
 import com.bfalls.suntimealerts.alarm.presentation.viewmodel.PermissionRequestOrigin
+import com.bfalls.suntimealerts.alarm.presentation.viewmodel.SettingsViewModel
+import com.bfalls.suntimealerts.alarm.presentation.viewmodel.SettingsViewModelFactory
 import com.bfalls.suntimealerts.alarm.services.NotificationScheduler
 import com.bfalls.suntimealerts.cities.data.CityRepository
 import com.bfalls.suntimealerts.cities.presentation.CityImportViewModel
@@ -80,6 +83,9 @@ class MainActivity : ComponentActivity() {
             val scheduleService = remember { SunScheduleService(sunTimesCalculator, settingsStore, notificationScheduler) }
             val cityRepository = remember { CityRepository(applicationContext) }
             val homeViewModel = remember { HomeViewModel(locationService, settingsStore, scheduleService, sunTimesCalculator) }
+            val settingsViewModel: SettingsViewModel = viewModel(
+                factory = SettingsViewModelFactory(settingsStore, cityRepository, locationService, applicationContext)
+            )
             val onboardingViewModel: OnboardingViewModel = viewModel(
                 factory = OnboardingViewModelFactory(settingsStore, cityRepository, locationService)
             )
@@ -92,6 +98,7 @@ class MainActivity : ComponentActivity() {
             var autoLocationPermissionRequested by rememberSaveable { mutableStateOf(false) }
             var pendingExactAlarmPermissionRequest by rememberSaveable { mutableStateOf(false) }
             var awaitingExactAlarmOnboardingResult by rememberSaveable { mutableStateOf(false) }
+            var showSettings by rememberSaveable { mutableStateOf(false) }
             val alarmManager = remember { getSystemService(ALARM_SERVICE) as AlarmManager }
             val exactAlarmPermissionTracker = remember { ExactAlarmPermissionTracker(applicationContext) }
             val notificationPermissionLauncher =
@@ -268,6 +275,12 @@ class MainActivity : ComponentActivity() {
                 }
             }
 
+            LaunchedEffect(onboardingState.onboardingComplete) {
+                if (!onboardingState.onboardingComplete) {
+                    showSettings = false
+                }
+            }
+
             SuntimeAlertsTheme {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
@@ -296,89 +309,104 @@ class MainActivity : ComponentActivity() {
                             }
                         }
                         !onboardingState.isLoaded -> Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { CircularProgressIndicator() }
-                        onboardingState.onboardingComplete -> HomeScreen(viewModel = homeViewModel)
-                        else -> OnboardingScreen(
-                            state = onboardingState,
-                            onLocationModeChanged = { mode ->
-                                when (mode) {
-                                    LocationMode.DEVICE -> {
-                                        onboardingViewModel.updateLocationMode(LocationMode.DEVICE)
+                        !onboardingState.onboardingComplete -> {
+                            OnboardingScreen(
+                                state = onboardingState,
+                                onLocationModeChanged = { mode ->
+                                    when (mode) {
+                                        LocationMode.DEVICE -> {
+                                            onboardingViewModel.updateLocationMode(LocationMode.DEVICE)
 
-                                        if (hasLocationPermission(context)) {
-                                            // Already granted → just switch to device mode
-                                            onboardingViewModel.clearLocationPermissionDenial()
-                                            return@OnboardingScreen
-                                        }
+                                            if (hasLocationPermission(context)) {
+                                                // Already granted → just switch to device mode
+                                                onboardingViewModel.clearLocationPermissionDenial()
+                                                return@OnboardingScreen
+                                            }
 
-                                        // Trigger system permission dialog after the UI switches to device mode
-                                        permissionRequestOrigin = PermissionRequestOrigin.USER
-                                        locationPermissionLauncher.launch(
-                                            arrayOf(
-                                                Manifest.permission.ACCESS_FINE_LOCATION,
-                                                Manifest.permission.ACCESS_COARSE_LOCATION
+                                            // Trigger system permission dialog after the UI switches to device mode
+                                            permissionRequestOrigin = PermissionRequestOrigin.USER
+                                            locationPermissionLauncher.launch(
+                                                arrayOf(
+                                                    Manifest.permission.ACCESS_FINE_LOCATION,
+                                                    Manifest.permission.ACCESS_COARSE_LOCATION
+                                                )
                                             )
-                                        )
+                                        }
+                                        LocationMode.FIXED -> {
+                                            onboardingViewModel.updateLocationMode(LocationMode.FIXED)
+                                        }
                                     }
-                                    LocationMode.FIXED -> {
-                                        onboardingViewModel.updateLocationMode(LocationMode.FIXED)
+                                },
+                                onOpenPermissionSettings = {
+                                    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                                        data = Uri.fromParts("package", packageName, null)
                                     }
-                                }
-                            },
-                            onOpenPermissionSettings = {
-                                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-                                    data = Uri.fromParts("package", packageName, null)
-                                }
-                                startActivity(intent)
-                            },
-                            onCityQueryChanged = onboardingViewModel::updateCityQuery,
-                            onCitySelected = onboardingViewModel::selectCity,
-                            notificationsPermissionRequired = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-                                !hasNotificationPermission(context),
-                            exactAlarmPermissionRequired = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
-                                !alarmManager.canScheduleExactAlarms(),
-                            onNotificationsContinue = {
-                                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                                    startActivity(intent)
+                                },
+                                onCityQueryChanged = onboardingViewModel::updateCityQuery,
+                                onCitySelected = onboardingViewModel::selectCity,
+                                notificationsPermissionRequired = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                                    !hasNotificationPermission(context),
+                                exactAlarmPermissionRequired = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                                    !alarmManager.canScheduleExactAlarms(),
+                                onNotificationsContinue = {
+                                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                                        onboardingViewModel.nextStep()
+                                        return@OnboardingScreen
+                                    }
+                                    if (hasNotificationPermission(context)) {
+                                        onboardingViewModel.nextStep()
+                                    } else {
+                                        notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                                    }
+                                },
+                                onNotificationsSkip = onboardingViewModel::nextStep,
+                                onExactAlarmsContinue = {
+                                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+                                        onboardingViewModel.nextStep()
+                                        return@OnboardingScreen
+                                    }
+                                    if (alarmManager.canScheduleExactAlarms()) {
+                                        exactAlarmPermissionTracker.reset()
+                                        onboardingViewModel.nextStep()
+                                        return@OnboardingScreen
+                                    }
+                                    if (pendingExactAlarmPermissionRequest) {
+                                        return@OnboardingScreen
+                                    }
+                                    pendingExactAlarmPermissionRequest = true
+                                    if (
+                                        onboardingState.step == OnboardingStep.EXACT_ALARMS &&
+                                        !onboardingState.onboardingComplete
+                                    ) {
+                                        awaitingExactAlarmOnboardingResult = true
+                                    }
+                                    startActivity(Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM))
+                                },
+                                onExactAlarmsSkip = {
+                                    pendingExactAlarmPermissionRequest = false
+                                    awaitingExactAlarmOnboardingResult = false
                                     onboardingViewModel.nextStep()
-                                    return@OnboardingScreen
-                                }
-                                if (hasNotificationPermission(context)) {
-                                    onboardingViewModel.nextStep()
-                                } else {
-                                    notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-                                }
+                                },
+                                onNext = onboardingViewModel::nextStep,
+                                onBack = onboardingViewModel::previousStep,
+                                onComplete = { onboardingViewModel.complete { } },
+                                canAdvance = onboardingViewModel.canAdvance()
+                            )
+                        }
+                        showSettings -> SettingsScreen(
+                            viewModel = settingsViewModel,
+                            onBack = { showSettings = false },
+                            onLocationUpdated = {
+                                homeViewModel.refresh()
                             },
-                            onNotificationsSkip = onboardingViewModel::nextStep,
-                            onExactAlarmsContinue = {
-                                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
-                                    onboardingViewModel.nextStep()
-                                    return@OnboardingScreen
-                                }
-                                if (alarmManager.canScheduleExactAlarms()) {
-                                    exactAlarmPermissionTracker.reset()
-                                    onboardingViewModel.nextStep()
-                                    return@OnboardingScreen
-                                }
-                                if (pendingExactAlarmPermissionRequest) {
-                                    return@OnboardingScreen
-                                }
-                                pendingExactAlarmPermissionRequest = true
-                                if (
-                                    onboardingState.step == OnboardingStep.EXACT_ALARMS &&
-                                    !onboardingState.onboardingComplete
-                                ) {
-                                    awaitingExactAlarmOnboardingResult = true
-                                }
-                                startActivity(Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM))
-                            },
-                            onExactAlarmsSkip = {
-                                pendingExactAlarmPermissionRequest = false
-                                awaitingExactAlarmOnboardingResult = false
-                                onboardingViewModel.nextStep()
-                            },
-                            onNext = onboardingViewModel::nextStep,
-                            onBack = onboardingViewModel::previousStep,
-                            onComplete = { onboardingViewModel.complete { } },
-                            canAdvance = onboardingViewModel.canAdvance()
+                            onSkyBodySizeUpdated = {
+                                homeViewModel.refresh()
+                            }
+                        )
+                        else -> HomeScreen(
+                            viewModel = homeViewModel,
+                            onOpenSettings = { showSettings = true }
                         )
                     }
                 }

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/data/SettingsStore.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/data/SettingsStore.kt
@@ -16,6 +16,7 @@ import com.bfalls.suntimealerts.alarm.domain.model.DEFAULT_SUNSET_ALARM_ID
 import com.bfalls.suntimealerts.alarm.domain.model.SunAlarm
 import com.bfalls.suntimealerts.alarm.domain.model.SunAlarmConfig
 import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
+import com.bfalls.suntimealerts.alarm.domain.model.AppThemeMode
 import com.bfalls.suntimealerts.alarm.domain.model.SkyBodySize
 import com.bfalls.suntimealerts.alarm.domain.model.UserSettings
 import com.bfalls.suntimealerts.alarm.domain.model.withDefaults
@@ -42,6 +43,7 @@ class SettingsStore(private val context: Context) : SettingsRepository {
     private val onboarding = booleanPreferencesKey("onboarding")
     private val alarmsJson = stringPreferencesKey("alarms_json")
     private val skyBodySize = stringPreferencesKey("sky_body_size")
+    private val appThemeMode = stringPreferencesKey("app_theme_mode")
     private val gson = Gson()
 
     override suspend fun load(): UserSettings {
@@ -83,7 +85,10 @@ class SettingsStore(private val context: Context) : SettingsRepository {
             alarms = alarms,
             skyBodySize = prefs[skyBodySize]?.let { stored ->
                 runCatching { SkyBodySize.valueOf(stored) }.getOrDefault(SkyBodySize.SMALL)
-            } ?: SkyBodySize.SMALL
+            } ?: SkyBodySize.SMALL,
+            appThemeMode = prefs[appThemeMode]?.let { stored ->
+                runCatching { AppThemeMode.valueOf(stored) }.getOrDefault(AppThemeMode.SYSTEM)
+            } ?: AppThemeMode.SYSTEM
         )
     }
 
@@ -103,6 +108,7 @@ class SettingsStore(private val context: Context) : SettingsRepository {
             }
             prefs[alarmsJson] = gson.toJson(settings.alarms)
             prefs[skyBodySize] = settings.skyBodySize.name
+            prefs[appThemeMode] = settings.appThemeMode.name
         }
     }
 

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/data/SettingsStore.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/data/SettingsStore.kt
@@ -16,6 +16,7 @@ import com.bfalls.suntimealerts.alarm.domain.model.DEFAULT_SUNSET_ALARM_ID
 import com.bfalls.suntimealerts.alarm.domain.model.SunAlarm
 import com.bfalls.suntimealerts.alarm.domain.model.SunAlarmConfig
 import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
+import com.bfalls.suntimealerts.alarm.domain.model.SkyBodySize
 import com.bfalls.suntimealerts.alarm.domain.model.UserSettings
 import com.bfalls.suntimealerts.alarm.domain.model.withDefaults
 import com.google.gson.Gson
@@ -40,6 +41,7 @@ class SettingsStore(private val context: Context) : SettingsRepository {
     private val fixedLon = doublePreferencesKey("fixed_lon")
     private val onboarding = booleanPreferencesKey("onboarding")
     private val alarmsJson = stringPreferencesKey("alarms_json")
+    private val skyBodySize = stringPreferencesKey("sky_body_size")
     private val gson = Gson()
 
     override suspend fun load(): UserSettings {
@@ -78,7 +80,10 @@ class SettingsStore(private val context: Context) : SettingsRepository {
             sunsetConfig = sunsetConfig,
             timeFormat24h = prefs[time24h] ?: true,
             onboardingComplete = prefs[onboarding] ?: false,
-            alarms = alarms
+            alarms = alarms,
+            skyBodySize = prefs[skyBodySize]?.let { stored ->
+                runCatching { SkyBodySize.valueOf(stored) }.getOrDefault(SkyBodySize.SMALL)
+            } ?: SkyBodySize.SMALL
         )
     }
 
@@ -97,6 +102,7 @@ class SettingsStore(private val context: Context) : SettingsRepository {
                 prefs.remove(fixedLon)
             }
             prefs[alarmsJson] = gson.toJson(settings.alarms)
+            prefs[skyBodySize] = settings.skyBodySize.name
         }
     }
 

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/domain/model/Models.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/domain/model/Models.kt
@@ -20,6 +20,12 @@ enum class LocationMode {
     FIXED;
 }
 
+enum class AppThemeMode {
+    SYSTEM,
+    LIGHT,
+    DARK
+}
+
 enum class SkyBodySize {
     SMALL,
     MEDIUM,
@@ -34,5 +40,6 @@ data class UserSettings(
     val timeFormat24h: Boolean,
     val onboardingComplete: Boolean,
     val alarms: List<SunAlarm> = emptyList(),
-    val skyBodySize: SkyBodySize = SkyBodySize.SMALL
+    val skyBodySize: SkyBodySize = SkyBodySize.SMALL,
+    val appThemeMode: AppThemeMode = AppThemeMode.SYSTEM
 )

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/domain/model/Models.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/domain/model/Models.kt
@@ -20,6 +20,12 @@ enum class LocationMode {
     FIXED;
 }
 
+enum class SkyBodySize {
+    SMALL,
+    MEDIUM,
+    LARGE
+}
+
 data class UserSettings(
     val locationMode: LocationMode,
     val fixedLocation: Coordinate? = null,
@@ -27,5 +33,6 @@ data class UserSettings(
     val sunsetConfig: SunAlarmConfig,
     val timeFormat24h: Boolean,
     val onboardingComplete: Boolean,
-    val alarms: List<SunAlarm> = emptyList()
+    val alarms: List<SunAlarm> = emptyList(),
+    val skyBodySize: SkyBodySize = SkyBodySize.SMALL
 )

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreen.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreen.kt
@@ -3,14 +3,10 @@ package com.bfalls.suntimealerts.alarm.presentation.ui
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
-import android.graphics.Paint
-import android.graphics.drawable.ColorDrawable
 import android.media.RingtoneManager
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings
-import android.widget.EditText
-import android.widget.NumberPicker
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -37,6 +33,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 //import androidx.compose.foundation.lazy.stickyHeader
 import androidx.compose.material.icons.Icons
@@ -85,6 +82,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -96,10 +94,12 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.TileMode
 import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.res.imageResource
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.semantics.semantics
@@ -107,7 +107,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import com.bfalls.suntimealerts.R
@@ -126,6 +125,9 @@ import com.bfalls.suntimealerts.alarm.domain.service.SunXY
 import com.bfalls.suntimealerts.alarm.presentation.viewmodel.HomeViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import java.time.Duration
 import java.time.ZonedDateTime
@@ -819,51 +821,123 @@ private fun OffsetPicker(
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceEvenly
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        NumberPickerColumn(
+        WheelPickerColumn(
             label = "Hours",
             value = hours,
             range = 0..23,
-            onValueChange = onHoursChanged
+            onValueChange = onHoursChanged,
+            modifier = Modifier.weight(1f)
         )
-        NumberPickerColumn(
+        WheelPickerColumn(
             label = "Minutes",
             value = minutes,
             range = 0..59,
-            onValueChange = onMinutesChanged
+            onValueChange = onMinutesChanged,
+            modifier = Modifier.weight(1f)
         )
     }
 }
 
 @Composable
-private fun NumberPickerColumn(
+private fun WheelPickerColumn(
     label: String,
     value: Int,
     range: IntRange,
-    onValueChange: (Int) -> Unit
+    onValueChange: (Int) -> Unit,
+    visibleCount: Int = 5,
+    modifier: Modifier = Modifier
 ) {
-    val pickerTextColor = MaterialTheme.colorScheme.onSurface
-    val pickerDividerColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.7f)
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(text = label, fontWeight = FontWeight.Bold)
-        AndroidView(
-            factory = { context ->
-                NumberPicker(context).apply {
-                    minValue = range.first
-                    maxValue = range.last
-                    setBackgroundColor(android.graphics.Color.TRANSPARENT)
-                    setOnValueChangedListener { _, _, newVal -> onValueChange(newVal) }
-                    styleNumberPicker(this, pickerTextColor, pickerDividerColor)
+    val coercedVisible = visibleCount.coerceAtLeast(3).let { if (it % 2 == 0) it + 1 else it }
+    val halfCount = coercedVisible / 2
+    val itemHeight = 36.dp
+    val values = remember(range) { range.toList() }
+    val listState = rememberLazyListState(initialFirstVisibleItemIndex = values.indexOf(value).coerceAtLeast(0))
+    val density = LocalDensity.current
+
+    LaunchedEffect(value, values) {
+        val targetIndex = values.indexOf(value).takeIf { it >= 0 } ?: return@LaunchedEffect
+        if (targetIndex != listState.firstVisibleItemIndex) {
+            listState.animateScrollToItem(targetIndex)
+        }
+    }
+
+    LaunchedEffect(listState, values) {
+        snapshotFlow { listState.isScrollInProgress }
+            .filter { !it }
+            .collectLatest {
+                val layoutInfo = listState.layoutInfo
+                val viewportCenter = (layoutInfo.viewportStartOffset + layoutInfo.viewportEndOffset) / 2f
+                val centered = layoutInfo.visibleItemsInfo.minByOrNull { item ->
+                    kotlin.math.abs((item.offset + item.size / 2f) - viewportCenter)
+                } ?: return@collectLatest
+                val centeredValue = values.getOrNull(centered.index) ?: return@collectLatest
+                if (centeredValue != value) {
+                    onValueChange(centeredValue)
                 }
-            },
-            update = {
-                if (it.value != value) {
-                    it.value = value.coerceIn(range)
-                }
-                styleNumberPicker(it, pickerTextColor, pickerDividerColor)
             }
-        )
+    }
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .then(modifier)
+            .semantics { contentDescription = "$label picker, selected $value" }
+    ) {
+        Text(text = label, fontWeight = FontWeight.Bold)
+        Box(
+            modifier = Modifier
+                .height(itemHeight * coercedVisible)
+                .fillMaxWidth()
+        ) {
+            LazyColumn(
+                state = listState,
+                contentPadding = PaddingValues(vertical = itemHeight * halfCount),
+                modifier = Modifier
+                    .fillMaxSize()
+            ) {
+                items(values) { entry ->
+                    val isSelected = entry == value
+                    val alpha = if (isSelected) 1f else 0.4f
+                    Box(
+                        modifier = Modifier
+                            .height(itemHeight)
+                            .fillMaxWidth(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = entry.toString(),
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = alpha),
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                    }
+                }
+            }
+            val outlineColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.8f)
+            val dividerStroke = with(density) { 1.dp.toPx() }
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .padding(horizontal = 16.dp)
+                    .drawBehind {
+                        val centerY = size.height / 2f
+                        val halfHeightPx = with(density) { itemHeight.toPx() / 2f }
+                        drawLine(
+                            color = outlineColor,
+                            start = Offset(0f, centerY - halfHeightPx),
+                            end = Offset(size.width, centerY - halfHeightPx),
+                            strokeWidth = dividerStroke
+                        )
+                        drawLine(
+                            color = outlineColor,
+                            start = Offset(0f, centerY + halfHeightPx),
+                            end = Offset(size.width, centerY + halfHeightPx),
+                            strokeWidth = dividerStroke
+                        )
+                    }
+            )
+        }
     }
 }
 
@@ -1134,38 +1208,6 @@ private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawStars(
     }
 }
 
-@SuppressLint("SoonBlockedPrivateApi")
-private fun styleNumberPicker(
-    numberPicker: NumberPicker,
-    textColor: Color,
-    dividerColor: Color
-) {
-    val textColorInt = textColor.toArgb()
-    for (index in 0 until numberPicker.childCount) {
-        val child = numberPicker.getChildAt(index)
-        if (child is EditText) {
-            child.setTextColor(textColorInt)
-        }
-    }
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-        try {
-            val selectorWheelPaintField = NumberPicker::class.java.getDeclaredField("mSelectorWheelPaint")
-            selectorWheelPaintField.isAccessible = true
-            val paint = selectorWheelPaintField.get(numberPicker) as Paint
-            paint.color = textColorInt
-        } catch (_: Exception) {
-            // Best-effort styling for OEM variations.
-        }
-        try {
-            val selectionDividerField = NumberPicker::class.java.getDeclaredField("mSelectionDivider")
-            selectionDividerField.isAccessible = true
-            selectionDividerField.set(numberPicker, ColorDrawable(dividerColor.toArgb()))
-        } catch (_: Exception) {
-            // Ignore if the field is not available.
-        }
-    }
-    numberPicker.invalidate()
-}
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun AlarmLists(

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreen.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/HomeScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -111,6 +112,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import com.bfalls.suntimealerts.R
 import com.bfalls.suntimealerts.alarm.domain.model.Coordinate
+import com.bfalls.suntimealerts.alarm.domain.model.SkyBodySize
 import com.bfalls.suntimealerts.alarm.domain.model.SunAlarm
 import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
 import com.bfalls.suntimealerts.alarm.domain.model.ALL_DAYS_MASK
@@ -141,7 +143,10 @@ private fun Modifier.moonVisible(isVisible: Boolean): Modifier = semantics {
 }
 
 @Composable
-fun HomeScreen(viewModel: HomeViewModel) {
+fun HomeScreen(
+    viewModel: HomeViewModel,
+    onOpenSettings: () -> Unit
+) {
     val state by viewModel.state.collectAsState()
     val lifecycleOwner = LocalLifecycleOwner.current
 
@@ -162,7 +167,8 @@ fun HomeScreen(viewModel: HomeViewModel) {
         onToggleAlarmEnabled = viewModel::toggleAlarmEnabled,
         onDeleteAlarm = viewModel::deleteAlarm,
         onDuplicateAlarm = viewModel::duplicateAlarm,
-        onRestoreAlarm = viewModel::restoreAlarm
+        onRestoreAlarm = viewModel::restoreAlarm,
+        onOpenSettings = onOpenSettings
     )
 }
 
@@ -175,7 +181,8 @@ fun HomeScreenContent(
     onToggleAlarmEnabled: (String, Boolean) -> Unit,
     onDeleteAlarm: (String) -> Unit,
     onDuplicateAlarm: (SunAlarm) -> Unit,
-    onRestoreAlarm: (SunAlarm, Int) -> Unit
+    onRestoreAlarm: (SunAlarm, Int) -> Unit,
+    onOpenSettings: () -> Unit
 ) {
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -226,7 +233,9 @@ fun HomeScreenContent(
                     moonIsWaxing = state.moonIsWaxing,
                     coordinateUsed = state.coordinateUsed,
                     sunTimesResolved = readyToRender,
-                    now = state.now
+                    now = state.now,
+                    skyBodySize = state.skyBodySize,
+                    onOpenSettings = onOpenSettings
                 )
             }
         },
@@ -870,7 +879,9 @@ private fun SkyTopBar(
     moonIsWaxing: Boolean,
     coordinateUsed: Coordinate?,
     sunTimesResolved: Boolean,
-    now: ZonedDateTime
+    now: ZonedDateTime,
+    skyBodySize: SkyBodySize,
+    onOpenSettings: () -> Unit
 ) {
     Box(
         modifier = Modifier
@@ -888,6 +899,7 @@ private fun SkyTopBar(
             coordinateUsed = coordinateUsed,
             sunTimesResolved = sunTimesResolved,
             now = now,
+            skyBodySize = skyBodySize,
             modifier = Modifier
                 .matchParentSize()
                 .testTag("sky_appbar_background")
@@ -899,7 +911,12 @@ private fun SkyTopBar(
                 scrolledContainerColor = Color.Transparent,
                 titleContentColor = Color.White,
                 actionIconContentColor = Color.White
-            )
+            ),
+            actions = {
+                IconButton(onClick = onOpenSettings) {
+                    Icon(Icons.Filled.Settings, contentDescription = "Settings")
+                }
+            }
         )
     }
 }
@@ -916,6 +933,7 @@ private fun SkyAppBarBackground(
     coordinateUsed: Coordinate?,
     sunTimesResolved: Boolean,
     now: ZonedDateTime,
+    skyBodySize: SkyBodySize,
     modifier: Modifier = Modifier
 ) {
     val hasSunTimes = sunTimesResolved && sunrise != null && sunset != null
@@ -925,6 +943,11 @@ private fun SkyAppBarBackground(
     val sunImage: ImageBitmap = ImageBitmap.imageResource(id = R.drawable.sun)
     val placeholderTop = MaterialTheme.colorScheme.surfaceColorAtElevation(6.dp)
     val placeholderBottom = MaterialTheme.colorScheme.surfaceColorAtElevation(12.dp)
+    val bodyScale = when (skyBodySize) {
+        SkyBodySize.SMALL -> 1.0f
+        SkyBodySize.MEDIUM -> 1.25f
+        SkyBodySize.LARGE -> 1.5f
+    }
     Canvas(modifier = modifier.moonVisible(moonIsAboveHorizon)) {
         val dayLengthMinutes = if (sunrise != null && sunset != null) {
             Duration.between(sunrise, sunset).toMinutes()
@@ -1012,9 +1035,9 @@ private fun SkyAppBarBackground(
 
         val moonShouldDraw = moonWindowComplete && moonPosition.isUp
         if (moonShouldDraw) {
-            val moonBaseDiameter = size.minDimension * 0.10f
-            val minMoonSize = 20.dp.toPx()
-            val maxMoonSize = 36.dp.toPx()
+            val moonBaseDiameter = size.minDimension * 0.10f * bodyScale
+            val minMoonSize = 20.dp.toPx() * bodyScale
+            val maxMoonSize = 36.dp.toPx() * bodyScale
             val moonDiameter = moonBaseDiameter.coerceIn(minMoonSize, maxMoonSize)
             val moonRadius = moonDiameter / 2f
             val topLeft = Offset(moonPosition.x - moonRadius, moonPosition.y - moonRadius)
@@ -1064,9 +1087,9 @@ private fun SkyAppBarBackground(
         }
 
         if (isDay) {
-            val sunBaseDiameter = size.minDimension * 0.12f
-            val minSunSize = 24.dp.toPx()
-            val maxSunSize = 40.dp.toPx()
+            val sunBaseDiameter = size.minDimension * 0.12f * bodyScale
+            val minSunSize = 24.dp.toPx() * bodyScale
+            val maxSunSize = 40.dp.toPx() * bodyScale
             val sunDiameter = sunBaseDiameter.coerceIn(minSunSize, maxSunSize)
             val sunRadius = sunDiameter / 2f
             val topLeft = Offset(sunPosition.x - sunRadius, sunPosition.y - sunRadius)

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/LocationPickerPane.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/LocationPickerPane.kt
@@ -1,0 +1,196 @@
+package com.bfalls.suntimealerts.alarm.presentation.ui
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MyLocation
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.TouchApp
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
+import com.bfalls.suntimealerts.cities.data.City
+
+data class LocationPickerUiState(
+    val locationMode: LocationMode = LocationMode.DEVICE,
+    val locationPermissionPermanentlyDenied: Boolean = false,
+    val locationPermissionMissing: Boolean = false,
+    val deviceNearestCityLabel: String? = null,
+    val fixedLatitude: String = "",
+    val fixedLongitude: String = "",
+    val cityQuery: String = "",
+    val cityResults: List<City> = emptyList(),
+    val selectedCity: City? = null
+)
+
+@Composable
+fun LocationPickerPane(
+    state: LocationPickerUiState,
+    onLocationModeChanged: (LocationMode) -> Unit,
+    onOpenPermissionSettings: () -> Unit,
+    onCityQueryChanged: (String) -> Unit,
+    onCitySelected: (City) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text("How should we find your location?")
+        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+            val options = listOf(
+                LocationMode.DEVICE to "Device",
+                LocationMode.FIXED to "Manual"
+            )
+            options.forEachIndexed { index, (mode, label) ->
+                val disabledDeviceOption =
+                    mode == LocationMode.DEVICE && state.locationPermissionPermanentlyDenied
+                SegmentedButton(
+                    modifier = if (disabledDeviceOption) Modifier.alpha(0.6f) else Modifier,
+                    shape = SegmentedButtonDefaults.itemShape(index, options.size),
+                    selected = state.locationMode == mode,
+                    enabled = !disabledDeviceOption,
+                    colors = SegmentedButtonDefaults.colors(),
+                    onClick = { onLocationModeChanged(mode) },
+                    icon = {
+                        when (mode) {
+                            LocationMode.DEVICE -> Icon(
+                                imageVector = Icons.Filled.MyLocation,
+                                contentDescription = null
+                            )
+                            LocationMode.FIXED -> Icon(
+                                imageVector = Icons.Filled.TouchApp,
+                                contentDescription = null
+                            )
+                        }
+                    },
+                    label = { Text(label) }
+                )
+            }
+        }
+        if (state.locationPermissionPermanentlyDenied || state.locationPermissionMissing) {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    if (state.locationPermissionPermanentlyDenied) {
+                        "Location permission is disabled. Open Settings to enable device location."
+                    } else {
+                        "Location permission is not granted. Open Settings to enable device location."
+                    }
+                )
+                OutlinedButton(onClick = onOpenPermissionSettings) {
+                    Text("Open Settings")
+                }
+            }
+        }
+        if (state.locationMode == LocationMode.FIXED) {
+            OutlinedTextField(
+                value = state.cityQuery,
+                onValueChange = onCityQueryChanged,
+                label = { Text("City") },
+                placeholder = { Text("Start typing a city name") },
+                modifier = Modifier.fillMaxWidth(),
+                leadingIcon = { Icon(imageVector = Icons.Filled.Search, contentDescription = null) },
+                shape = RoundedCornerShape(14.dp),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = MaterialTheme.colorScheme.primary,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.outline,
+                    focusedContainerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(4.dp),
+                    unfocusedContainerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp),
+                    cursorColor = MaterialTheme.colorScheme.primary,
+                    focusedLabelColor = MaterialTheme.colorScheme.primary,
+                    unfocusedLabelColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+                    focusedLeadingIconColor = MaterialTheme.colorScheme.primary,
+                    unfocusedLeadingIconColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f)
+                )
+            )
+            if (state.cityQuery.trim().length >= 2) {
+                if (state.cityResults.isEmpty()) {
+                    Text("No matching cities yet")
+                } else {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = 300.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        contentPadding = PaddingValues(vertical = 4.dp)
+                    ) {
+                        items(state.cityResults) { city ->
+                            Card(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable(
+                                        role = Role.Button,
+                                        onClick = { onCitySelected(city) }
+                                    ),
+                                shape = RoundedCornerShape(14.dp),
+                                colors = CardDefaults.elevatedCardColors(
+                                    containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(6.dp)
+                                ),
+                                border = BorderStroke(
+                                    width = 1.dp,
+                                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.45f)
+                                ),
+                                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+                            ) {
+                                Column(modifier = Modifier.padding(16.dp)) {
+                                    Text("${city.name}, ${city.countryCode}", fontWeight = FontWeight.SemiBold)
+                                    Text(
+                                        "${city.admin1Code} - ${city.lat}, ${city.lon}",
+                                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            when {
+                state.selectedCity != null -> {
+                    val selected = state.selectedCity
+                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Text("Selected city")
+                        Text("${selected.name}, ${selected.admin1Code}, ${selected.countryCode}")
+                        Text("Lat/Lon: ${selected.lat}, ${selected.lon}")
+                    }
+                }
+
+                state.fixedLatitude.isNotBlank() && state.fixedLongitude.isNotBlank() -> {
+                    Text("Current coordinates: ${state.fixedLatitude}, ${state.fixedLongitude}")
+                }
+            }
+        }
+        if (state.locationMode == LocationMode.DEVICE) {
+            when (val label = state.deviceNearestCityLabel) {
+                null -> Text("Finding nearest city...")
+                else -> Text("Nearest city: $label")
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/OnboardingScreen.kt
@@ -1,46 +1,23 @@
 package com.bfalls.suntimealerts.alarm.presentation.ui
 
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.ui.draw.alpha
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MyLocation
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.TouchApp
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
@@ -138,12 +115,22 @@ fun OnboardingScreen(
 
                 when (state.step) {
                     OnboardingStep.WELCOME -> WelcomeStep()
-                    OnboardingStep.LOCATION -> LocationStep(
-                        state,
-                        onLocationModeChanged,
-                        onOpenPermissionSettings,
-                        onCityQueryChanged,
-                        onCitySelected
+                    OnboardingStep.LOCATION -> LocationPickerPane(
+                        state = LocationPickerUiState(
+                            locationMode = state.locationMode,
+                            locationPermissionPermanentlyDenied = state.locationPermissionPermanentlyDenied,
+                            locationPermissionMissing = state.locationPermissionPermanentlyDenied,
+                            deviceNearestCityLabel = state.deviceNearestCityLabel,
+                            fixedLatitude = state.fixedLatitude,
+                            fixedLongitude = state.fixedLongitude,
+                            cityQuery = state.cityQuery,
+                            cityResults = state.cityResults,
+                            selectedCity = state.selectedCity
+                        ),
+                        onLocationModeChanged = onLocationModeChanged,
+                        onOpenPermissionSettings = onOpenPermissionSettings,
+                        onCityQueryChanged = onCityQueryChanged,
+                        onCitySelected = onCitySelected
                     )
                     OnboardingStep.NOTIFICATIONS -> NotificationsStep(
                         permissionRequired = notificationsPermissionRequired
@@ -163,146 +150,6 @@ private fun WelcomeStep() {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Text("Suntime Alerts keeps you aligned with sunrise and sunset.")
         Text("We will ask for location, notification access, and your preferred alarms.")
-    }
-}
-
-@Composable
-private fun LocationStep(
-    state: OnboardingState,
-    onLocationModeChanged: (LocationMode) -> Unit,
-    onOpenPermissionSettings: () -> Unit,
-    onCityQueryChanged: (String) -> Unit,
-    onCitySelected: (City) -> Unit
-) {
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        Text("How should we find your location?")
-        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-            val options = listOf(
-                LocationMode.DEVICE to "Device",
-                LocationMode.FIXED to "Manual"
-            )
-            options.forEachIndexed { index, (mode, label) ->
-                val disabledDeviceOption =
-                    mode == LocationMode.DEVICE && state.locationPermissionPermanentlyDenied
-                SegmentedButton(
-                    modifier = if (disabledDeviceOption) Modifier.alpha(0.6f) else Modifier,
-                    shape = SegmentedButtonDefaults.itemShape(index, options.size),
-                    selected = state.locationMode == mode,
-                    enabled = !disabledDeviceOption,
-                    colors = SegmentedButtonDefaults.colors(),
-                    onClick = { onLocationModeChanged(mode) },
-                    icon = {
-                        when (mode) {
-                            LocationMode.DEVICE -> Icon(
-                                imageVector = Icons.Filled.MyLocation,
-                                contentDescription = null
-                            )
-                            LocationMode.FIXED -> Icon(
-                                imageVector = Icons.Filled.TouchApp,
-                                contentDescription = null
-                            )
-                        }
-                    },
-                    label = { Text(label) }
-                )
-            }
-        }
-        if (state.locationPermissionPermanentlyDenied) {
-            Text("Location permission was denied twice. Enter your location manually to continue.")
-        }
-        if (state.locationMode == LocationMode.FIXED) {
-            OutlinedTextField(
-                value = state.cityQuery,
-                onValueChange = onCityQueryChanged,
-                label = { Text("City") },
-                placeholder = { Text("Start typing a city name") },
-                modifier = Modifier.fillMaxWidth(),
-                leadingIcon = { Icon(imageVector = Icons.Filled.Search, contentDescription = null) },
-                shape = RoundedCornerShape(14.dp),
-                colors = OutlinedTextFieldDefaults.colors(
-                    focusedBorderColor = MaterialTheme.colorScheme.primary,
-                    unfocusedBorderColor = MaterialTheme.colorScheme.outline,
-                    focusedContainerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(4.dp),
-                    unfocusedContainerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp),
-                    cursorColor = MaterialTheme.colorScheme.primary,
-                    focusedLabelColor = MaterialTheme.colorScheme.primary,
-                    unfocusedLabelColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
-                    focusedLeadingIconColor = MaterialTheme.colorScheme.primary,
-                    unfocusedLeadingIconColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f)
-                )
-            )
-            if (state.cityQuery.trim().length >= 2) {
-                if (state.cityResults.isEmpty()) {
-                    Text("No matching cities yet")
-                } else {
-                    LazyColumn(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .heightIn(max = 300.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                        contentPadding = PaddingValues(vertical = 4.dp)
-                    ) {
-                        items(state.cityResults) { city ->
-                            Card(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .clickable(
-                                        role = Role.Button,
-                                        onClick = { onCitySelected(city) }
-                                    ),
-                                shape = RoundedCornerShape(14.dp),
-                                colors = CardDefaults.elevatedCardColors(
-                                    containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(6.dp)
-                                ),
-                                border = BorderStroke(
-                                    width = 1.dp,
-                                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.45f)
-                                ),
-                                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-                            ) {
-                                Column(modifier = Modifier.padding(16.dp)) {
-                                    Text("${city.name}, ${city.countryCode}", fontWeight = FontWeight.SemiBold)
-                                    Text(
-                                        "${city.admin1Code} · ${city.lat}, ${city.lon}",
-                                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f)
-                                    )
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            when {
-                state.selectedCity != null -> {
-                    val selected = state.selectedCity
-                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        Text("Selected city")
-                        Text("${selected.name}, ${selected.admin1Code}, ${selected.countryCode}")
-                        Text("Lat/Lon: ${selected.lat}, ${selected.lon}")
-                    }
-                }
-
-                state.fixedLatitude.isNotBlank() && state.fixedLongitude.isNotBlank() -> {
-                    Text("Current coordinates: ${state.fixedLatitude}, ${state.fixedLongitude}")
-                }
-            }
-        }
-        if (state.locationMode == LocationMode.DEVICE) {
-            when (val label = state.deviceNearestCityLabel) {
-                null -> Text("Finding nearest city...")
-                else -> Text("Nearest city: $label")
-            }
-
-            if (state.locationPermissionPermanentlyDenied) {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Text("Location permission is disabled. Open Settings to enable device location.")
-                    OutlinedButton(onClick = onOpenPermissionSettings) {
-                        Text("Open Settings")
-                    }
-                }
-            }
-        }
     }
 }
 

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/SettingsScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.content.getSystemService
+import com.bfalls.suntimealerts.alarm.domain.model.AppThemeMode
 import com.bfalls.suntimealerts.alarm.domain.model.SkyBodySize
 import com.bfalls.suntimealerts.alarm.presentation.viewmodel.SettingsViewModel
 import com.bfalls.suntimealerts.utils.hasLocationPermission
@@ -234,6 +235,45 @@ fun SettingsScreen(
                             },
                             showAction = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !canScheduleExactAlarms
                         )
+                    }
+                }
+
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant
+                    )
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Text("Theme", fontWeight = FontWeight.SemiBold)
+                        val themeOptions = listOf(
+                            AppThemeMode.SYSTEM to "System",
+                            AppThemeMode.LIGHT to "Light",
+                            AppThemeMode.DARK to "Dark"
+                        )
+                        themeOptions.forEach { (mode, label) ->
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable(
+                                        role = Role.RadioButton,
+                                        onClick = { viewModel.updateAppThemeMode(mode) }
+                                    )
+                                    .padding(vertical = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                RadioButton(
+                                    selected = state.appThemeMode == mode,
+                                    onClick = { viewModel.updateAppThemeMode(mode) }
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(label)
+                            }
+                        }
                     }
                 }
 

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/ui/SettingsScreen.kt
@@ -1,0 +1,308 @@
+package com.bfalls.suntimealerts.alarm.presentation.ui
+
+import android.app.AlarmManager
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.core.content.getSystemService
+import com.bfalls.suntimealerts.alarm.domain.model.SkyBodySize
+import com.bfalls.suntimealerts.alarm.presentation.viewmodel.SettingsViewModel
+import com.bfalls.suntimealerts.utils.hasLocationPermission
+import com.bfalls.suntimealerts.utils.hasNotificationPermission
+import kotlinx.coroutines.launch
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+fun SettingsScreen(
+    viewModel: SettingsViewModel,
+    onBack: () -> Unit,
+    onLocationUpdated: () -> Unit,
+    onSkyBodySizeUpdated: () -> Unit
+) {
+    val state by viewModel.state.collectAsState()
+    val context = LocalContext.current
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+    val scrollState = rememberScrollState()
+    val alarmManager = remember { context.getSystemService<AlarmManager>() }
+    val hasLocationPermission = hasLocationPermission(context)
+    val notificationsPermissionGranted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        hasNotificationPermission(context)
+    } else {
+        true
+    }
+    val canScheduleExactAlarms = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        alarmManager?.canScheduleExactAlarms() == true
+    } else {
+        true
+    }
+
+    LaunchedEffect(hasLocationPermission) {
+        viewModel.updateLocationPermission(hasLocationPermission)
+    }
+
+    LaunchedEffect(state.errorMessage) {
+        state.errorMessage?.let { message ->
+            scope.launch {
+                snackbarHostState.showSnackbar(message)
+                viewModel.clearError()
+            }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Settings") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { padding ->
+        if (state.isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .verticalScroll(scrollState)
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant
+                    )
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Text("Location", fontWeight = FontWeight.SemiBold)
+                        LocationPickerPane(
+                            state = state.locationState.copy(
+                                locationPermissionMissing = !hasLocationPermission
+                            ),
+                            onLocationModeChanged = viewModel::updateLocationMode,
+                            onOpenPermissionSettings = {
+                                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                                    data = Uri.parse("package:${context.packageName}")
+                                }
+                                context.startActivity(intent)
+                            },
+                            onCityQueryChanged = viewModel::updateCityQuery,
+                            onCitySelected = viewModel::selectCity
+                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.End,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Button(
+                                onClick = {
+                                    viewModel.saveLocation {
+                                        onLocationUpdated()
+                                        scope.launch {
+                                            snackbarHostState.showSnackbar("Location updated")
+                                        }
+                                    }
+                                },
+                                enabled = viewModel.canSaveLocation() && !state.isSavingLocation
+                            ) {
+                                if (state.isSavingLocation) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier
+                                            .size(18.dp)
+                                            .padding(end = 8.dp),
+                                        strokeWidth = 2.dp
+                                    )
+                                }
+                                Text("Save location")
+                            }
+                        }
+                    }
+                }
+
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant
+                    )
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Text("Permissions", fontWeight = FontWeight.SemiBold)
+                        PermissionStatusRow(
+                            title = "Location",
+                            status = if (hasLocationPermission) "Allowed" else "Not allowed",
+                            actionLabel = "Open app settings",
+                            onActionClick = {
+                                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                                    data = Uri.parse("package:${context.packageName}")
+                                }
+                                context.startActivity(intent)
+                            },
+                            showAction = !hasLocationPermission
+                        )
+                        PermissionStatusRow(
+                            title = "Notifications",
+                            status = when {
+                                Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU -> "Not required on this Android version"
+                                notificationsPermissionGranted -> "Allowed"
+                                else -> "Not allowed"
+                            },
+                            actionLabel = "Open app settings",
+                            onActionClick = {
+                                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                                    data = Uri.parse("package:${context.packageName}")
+                                }
+                                context.startActivity(intent)
+                            },
+                            showAction = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && !notificationsPermissionGranted
+                        )
+                        PermissionStatusRow(
+                            title = "Alarms & reminders",
+                            status = when {
+                                Build.VERSION.SDK_INT < Build.VERSION_CODES.S -> "Not required on this Android version"
+                                canScheduleExactAlarms -> "Allowed"
+                                else -> "Not allowed"
+                            },
+                            actionLabel = "Open Alarms & reminders",
+                            onActionClick = {
+                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                                    context.startActivity(Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM))
+                                }
+                            },
+                            showAction = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !canScheduleExactAlarms
+                        )
+                    }
+                }
+
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant
+                    )
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Text("Banner display size", fontWeight = FontWeight.SemiBold)
+                        val options = listOf(
+                            SkyBodySize.SMALL to "Small",
+                            SkyBodySize.MEDIUM to "Medium",
+                            SkyBodySize.LARGE to "Large"
+                        )
+                        options.forEach { (size, label) ->
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable(
+                                        role = Role.RadioButton,
+                                        onClick = {
+                                            viewModel.updateSkyBodySize(size) {
+                                                onSkyBodySizeUpdated()
+                                            }
+                                        }
+                                    )
+                                    .padding(vertical = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                RadioButton(
+                                    selected = state.skyBodySize == size,
+                                    onClick = {
+                                        viewModel.updateSkyBodySize(size) {
+                                            onSkyBodySizeUpdated()
+                                        }
+                                    }
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(label)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PermissionStatusRow(
+    title: String,
+    status: String,
+    actionLabel: String,
+    onActionClick: () -> Unit,
+    showAction: Boolean
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(title, fontWeight = FontWeight.Medium)
+        Text(status, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        if (showAction) {
+            Button(onClick = onActionClick) {
+                Text(actionLabel)
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/HomeViewModel.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/HomeViewModel.kt
@@ -9,6 +9,7 @@ import com.bfalls.suntimealerts.alarm.domain.model.Coordinate
 import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
 import com.bfalls.suntimealerts.alarm.domain.model.SunAlarm
 import com.bfalls.suntimealerts.alarm.domain.model.SunEventType
+import com.bfalls.suntimealerts.alarm.domain.model.SkyBodySize
 import com.bfalls.suntimealerts.alarm.domain.model.UserSettings
 import com.bfalls.suntimealerts.alarm.domain.service.MoonEphemeris
 import com.bfalls.suntimealerts.alarm.domain.service.MoonTimesCalculator
@@ -54,6 +55,7 @@ class HomeViewModel(
         val moonIllumination01: Double = 0.0,
         val moonIsWaxing: Boolean = true,
         val now: ZonedDateTime = ZonedDateTime.now(ZoneId.systemDefault()),
+        val skyBodySize: SkyBodySize = SkyBodySize.SMALL,
         val error: String? = null
     )
 
@@ -70,6 +72,10 @@ class HomeViewModel(
     private var cachedSettings: UserSettings? = null
 
     init {
+        viewModelScope.launch { loadState() }
+    }
+
+    fun refresh() {
         viewModelScope.launch { loadState() }
     }
 
@@ -161,7 +167,8 @@ class HomeViewModel(
                     sunriseTime = placeholderSunTimes.sunrise,
                     sunsetTime = placeholderSunTimes.sunset,
                     sunriseTimeText = formatTime(placeholderSunTimes.sunrise, settings.timeFormat24h),
-                    sunsetTimeText = formatTime(placeholderSunTimes.sunset, settings.timeFormat24h)
+                    sunsetTimeText = formatTime(placeholderSunTimes.sunset, settings.timeFormat24h),
+                    skyBodySize = settings.skyBodySize
                 )
             }
 
@@ -238,6 +245,7 @@ class HomeViewModel(
                 moonMaxAltDeg = moonWindow?.maxAltDeg ?: current.moonMaxAltDeg,
                 moonIllumination01 = moonPhase.illumination01,
                 moonIsWaxing = moonPhase.isWaxing,
+                skyBodySize = resolvedSettings.skyBodySize,
                 now = now,
                 error = if (coordinate == null) "Location unavailable" else null
             )

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/SettingsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.bfalls.suntimealerts.alarm.data.LocationProvider
 import com.bfalls.suntimealerts.alarm.data.SettingsRepository
+import com.bfalls.suntimealerts.alarm.domain.model.AppThemeMode
 import com.bfalls.suntimealerts.alarm.domain.model.Coordinate
 import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
 import com.bfalls.suntimealerts.alarm.domain.model.SkyBodySize
@@ -24,6 +25,7 @@ data class SettingsUiState(
     val isLoading: Boolean = true,
     val locationState: LocationPickerUiState = LocationPickerUiState(),
     val skyBodySize: SkyBodySize = SkyBodySize.SMALL,
+    val appThemeMode: AppThemeMode = AppThemeMode.SYSTEM,
     val isSavingLocation: Boolean = false,
     val errorMessage: String? = null
 )
@@ -60,7 +62,8 @@ class SettingsViewModel(
                 cityQuery = settings.fixedLocation?.let { "" } ?: "",
                 selectedCity = null
             ),
-            skyBodySize = settings.skyBodySize
+            skyBodySize = settings.skyBodySize,
+            appThemeMode = settings.appThemeMode
         )
         if (settings.locationMode == LocationMode.DEVICE && !locationPermissionMissing) {
             refreshDeviceNearestCity()
@@ -184,6 +187,14 @@ class SettingsViewModel(
             settingsStore.save(settings)
             _state.update { current -> current.copy(skyBodySize = size) }
             onSaved()
+        }
+    }
+
+    fun updateAppThemeMode(mode: AppThemeMode) {
+        viewModelScope.launch {
+            val settings = settingsStore.load().copy(appThemeMode = mode)
+            settingsStore.save(settings)
+            _state.update { current -> current.copy(appThemeMode = mode) }
         }
     }
 

--- a/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/alarm/presentation/viewmodel/SettingsViewModel.kt
@@ -1,0 +1,225 @@
+package com.bfalls.suntimealerts.alarm.presentation.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.bfalls.suntimealerts.alarm.data.LocationProvider
+import com.bfalls.suntimealerts.alarm.data.SettingsRepository
+import com.bfalls.suntimealerts.alarm.domain.model.Coordinate
+import com.bfalls.suntimealerts.alarm.domain.model.LocationMode
+import com.bfalls.suntimealerts.alarm.domain.model.SkyBodySize
+import com.bfalls.suntimealerts.alarm.domain.model.UserSettings
+import com.bfalls.suntimealerts.alarm.presentation.ui.LocationPickerUiState
+import com.bfalls.suntimealerts.cities.data.City
+import com.bfalls.suntimealerts.cities.data.CityRepository
+import com.bfalls.suntimealerts.utils.hasLocationPermission
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class SettingsUiState(
+    val isLoading: Boolean = true,
+    val locationState: LocationPickerUiState = LocationPickerUiState(),
+    val skyBodySize: SkyBodySize = SkyBodySize.SMALL,
+    val isSavingLocation: Boolean = false,
+    val errorMessage: String? = null
+)
+
+class SettingsViewModel(
+    private val settingsStore: SettingsRepository,
+    private val cityRepository: CityRepository,
+    private val locationService: LocationProvider,
+    private val applicationContext: Context
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(SettingsUiState())
+    val state: StateFlow<SettingsUiState> = _state
+
+    private var searchJob: Job? = null
+    private var nearestCityJob: Job? = null
+
+    init {
+        viewModelScope.launch { load() }
+    }
+
+    private suspend fun load() {
+        val settings = settingsStore.load()
+        val locationPermissionMissing = !hasLocationPermission(applicationContext)
+        _state.value = SettingsUiState(
+            isLoading = false,
+            locationState = LocationPickerUiState(
+                locationMode = settings.locationMode,
+                locationPermissionPermanentlyDenied = false,
+                locationPermissionMissing = locationPermissionMissing,
+                deviceNearestCityLabel = null,
+                fixedLatitude = settings.fixedLocation?.latitude?.toString() ?: "",
+                fixedLongitude = settings.fixedLocation?.longitude?.toString() ?: "",
+                cityQuery = settings.fixedLocation?.let { "" } ?: "",
+                selectedCity = null
+            ),
+            skyBodySize = settings.skyBodySize
+        )
+        if (settings.locationMode == LocationMode.DEVICE && !locationPermissionMissing) {
+            refreshDeviceNearestCity()
+        }
+    }
+
+    fun updateLocationMode(mode: LocationMode) {
+        _state.update { current ->
+            current.copy(
+                locationState = current.locationState.copy(
+                    locationMode = mode,
+                    deviceNearestCityLabel = if (mode == LocationMode.DEVICE) null else current.locationState.deviceNearestCityLabel
+                )
+            )
+        }
+        if (mode == LocationMode.DEVICE) {
+            refreshDeviceNearestCity()
+        }
+    }
+
+    fun updateLocationPermission(granted: Boolean) {
+        _state.update { current ->
+            current.copy(
+                locationState = current.locationState.copy(
+                    locationPermissionMissing = !granted,
+                    locationPermissionPermanentlyDenied = current.locationState.locationPermissionPermanentlyDenied && !granted
+                )
+            )
+        }
+        if (granted && _state.value.locationState.locationMode == LocationMode.DEVICE) {
+            refreshDeviceNearestCity()
+        }
+    }
+
+    fun updateCityQuery(query: String) {
+        _state.update { current ->
+            current.copy(locationState = current.locationState.copy(cityQuery = query, selectedCity = null))
+        }
+        searchJob?.cancel()
+        searchJob = viewModelScope.launch {
+            val results = if (query.trim().length >= 2) {
+                cityRepository.searchCities(query)
+            } else {
+                emptyList()
+            }
+            _state.update { current ->
+                current.copy(locationState = current.locationState.copy(cityResults = results))
+            }
+        }
+    }
+
+    fun selectCity(city: City) {
+        _state.update { current ->
+            current.copy(
+                locationState = current.locationState.copy(
+                    selectedCity = city,
+                    cityQuery = "${city.name}, ${city.countryCode}",
+                    fixedLatitude = city.lat.toString(),
+                    fixedLongitude = city.lon.toString()
+                )
+            )
+        }
+    }
+
+    fun refreshDeviceNearestCity() {
+        if (!hasLocationPermission(applicationContext)) return
+        nearestCityJob?.cancel()
+        nearestCityJob = viewModelScope.launch {
+            _state.update { current ->
+                current.copy(locationState = current.locationState.copy(deviceNearestCityLabel = null))
+            }
+            val coordinate = locationService.currentCoordinate() ?: return@launch
+            val nearest = cityRepository.findNearestCity(coordinate.latitude, coordinate.longitude)
+            val label = nearest?.let { city ->
+                val region = city.admin1Code.takeIf { it.isNotBlank() }
+                if (region != null) {
+                    "${city.name}, $region, ${city.countryCode}"
+                } else {
+                    "${city.name}, ${city.countryCode}"
+                }
+            }
+            _state.update { current ->
+                current.copy(locationState = current.locationState.copy(deviceNearestCityLabel = label))
+            }
+        }
+    }
+
+    fun canSaveLocation(): Boolean {
+        val locationState = _state.value.locationState
+        return when (locationState.locationMode) {
+            LocationMode.DEVICE -> true
+            LocationMode.FIXED -> {
+                locationState.selectedCity != null || (
+                    locationState.fixedLatitude.toDoubleOrNull() != null &&
+                        locationState.fixedLongitude.toDoubleOrNull() != null
+                    )
+            }
+        }
+    }
+
+    fun saveLocation(onSaved: () -> Unit = {}) {
+        val currentState = _state.value
+        if (!canSaveLocation() || currentState.isSavingLocation) return
+        _state.update { it.copy(isSavingLocation = true, errorMessage = null) }
+        viewModelScope.launch {
+            try {
+                val loaded = settingsStore.load()
+                val updated = applyLocationToSettings(currentState.locationState, loaded)
+                settingsStore.save(updated)
+                _state.update { it.copy(isSavingLocation = false) }
+                onSaved()
+            } catch (t: Throwable) {
+                _state.update { it.copy(isSavingLocation = false, errorMessage = "Failed to save location") }
+            }
+        }
+    }
+
+    fun updateSkyBodySize(size: SkyBodySize, onSaved: () -> Unit = {}) {
+        viewModelScope.launch {
+            val settings = settingsStore.load().copy(skyBodySize = size)
+            settingsStore.save(settings)
+            _state.update { current -> current.copy(skyBodySize = size) }
+            onSaved()
+        }
+    }
+
+    fun clearError() {
+        _state.update { it.copy(errorMessage = null) }
+    }
+
+    private fun applyLocationToSettings(
+        locationState: LocationPickerUiState,
+        settings: UserSettings
+    ): UserSettings {
+        return when (locationState.locationMode) {
+            LocationMode.DEVICE -> settings.copy(locationMode = LocationMode.DEVICE, fixedLocation = null)
+            LocationMode.FIXED -> {
+                val lat = locationState.selectedCity?.lat ?: locationState.fixedLatitude.toDoubleOrNull() ?: 0.0
+                val lon = locationState.selectedCity?.lon ?: locationState.fixedLongitude.toDoubleOrNull() ?: 0.0
+                settings.copy(
+                    locationMode = LocationMode.FIXED,
+                    fixedLocation = Coordinate(lat, lon)
+                )
+            }
+        }
+    }
+}
+
+class SettingsViewModelFactory(
+    private val settingsStore: SettingsRepository,
+    private val cityRepository: CityRepository,
+    private val locationService: LocationProvider,
+    private val applicationContext: Context
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(SettingsViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return SettingsViewModel(settingsStore, cityRepository, locationService, applicationContext) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/android/app/src/main/java/com/bfalls/suntimealerts/ui/theme/Color.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/ui/theme/Color.kt
@@ -3,7 +3,6 @@ package com.bfalls.suntimealerts.ui.theme
 import androidx.compose.ui.graphics.Color
 
 val DeepNavy = Color(0xFF0B1D33)
-val SplashBackground = Color(0xFF0B1A2A)
 val SurfacePrimary = Color(0xFF121E2A)
 val SurfaceSecondary = Color(0xFF182435)
 val SunriseAccent = Color(0xFFF9A826)
@@ -11,3 +10,8 @@ val SunsetAccent = Color(0xFF5AD1FF)
 val TextPrimary = Color(0xFFF4F7FB)
 val TextSecondary = Color(0xFF9BB1CC)
 val OutlineMuted = Color(0xFF23344A)
+val LightSurfacePrimary = Color(0xFFF7FAFF)
+val LightSurfaceSecondary = Color(0xFFE8F0FA)
+val LightTextPrimary = Color(0xFF0B1D33)
+val LightTextSecondary = Color(0xFF4B5E73)
+val LightOutlineMuted = Color(0xFFCBD6E5)

--- a/android/app/src/main/java/com/bfalls/suntimealerts/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/bfalls/suntimealerts/ui/theme/Theme.kt
@@ -3,42 +3,26 @@ package com.bfalls.suntimealerts.ui.theme
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-
-private val DarkColorScheme = darkColorScheme(
-    primary = SunriseAccent,
-    secondary = SunsetAccent,
-    background = SurfacePrimary,
-    surface = SurfaceSecondary,
-    onPrimary = DeepNavy,
-    onSecondary = DeepNavy,
-    onBackground = TextPrimary,
-    onSurface = TextPrimary,
-    tertiary = OutlineMuted,
-    outline = OutlineMuted
-)
-
-private val LightColorScheme = lightColorScheme(
-    primary = SunriseAccent,
-    secondary = SunsetAccent,
-    background = SurfacePrimary,
-    surface = SurfaceSecondary,
-    onPrimary = DeepNavy,
-    onSecondary = DeepNavy,
-    onBackground = TextPrimary,
-    onSurface = TextPrimary,
-    tertiary = OutlineMuted,
-    outline = OutlineMuted
-)
+import androidx.compose.ui.platform.LocalContext
 
 @Composable
 fun SuntimeAlertsTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    dynamicColor: Boolean = false,
+    dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
+    val context = LocalContext.current
+    val colorScheme = when {
+        dynamicColor && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S ->
+            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+
+        darkTheme -> darkColorScheme()
+        else -> lightColorScheme()
+    }
 
     MaterialTheme(
         colorScheme = colorScheme,

--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="splash_background">#0B1A2A</color>
+</resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -7,5 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="splash_background">#0B1A2A</color> <!-- dark night-sky blue -->
+    <color name="splash_background">#F6FAFF</color>
 </resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.SuntimeAlerts" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.SuntimeAlerts" parent="Theme.AppCompat.DayNight.NoActionBar" />
     <style name="Theme.SuntimeAlerts.Splash" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/splash_background</item>
 


### PR DESCRIPTION
Fixes #59 

- Added a gear icon entry point on the home banner and wired MainActivity to toggle between home and a new full-screen Settings screen that refreshes the home view after updates.
- Built a reusable `LocationPickerPane` composable to share the manual/device location UI between onboarding and settings while preserving the existing city search flow.
- Introduced a persisted banner size preference and threaded it through settings, view model state, and the sky renderer to scale sun and moon drawings based on the selected size.
- Added an AppThemeMode enum to user settings and persisted it in DataStore with a dedicated preference key so theme choices survive restarts.
- Surfaced theme controls on the Settings screen and wired the view model to update and broadcast the selected mode immediately for recomposition.
- Applied the selected theme at the app root via AppCompatDelegate and refreshed the light/dark color palettes and splash resources to align splash, onboarding, and home surfaces with the chosen mode.